### PR TITLE
feat: Replace Buffer with Uint8Array for Prisma v6 compatibility

### DIFF
--- a/src/generator/generate-scalars.ts
+++ b/src/generator/generate-scalars.ts
@@ -31,4 +31,37 @@ export function generateCustomScalars(
       },
     });
   `);
+
+  sourceFile.addStatements(/* ts */ `
+    function uint8ArrayToBase64(uint8Array: Uint8Array) {
+      return Buffer.from(uint8Array).toString("base64");
+    }
+
+    function base64ToUint8Array(base64: string) {
+      return new Uint8Array(Buffer.from(base64, "base64"));
+    }
+
+    export const BytesScalar = new GraphQLScalarType({
+      name: "Bytes",
+      description: "GraphQL Scalar representing the Prisma.Bytes type.",
+      serialize: (value: unknown) => {
+        if (!(value instanceof Uint8Array)) {
+          throw new Error(\`[BytesError] Invalid argument: \${Object.prototype.toString.call(value)}. Expected Uint8Array.\`);
+        }
+        return uint8ArrayToBase64(value);
+      },
+      parseValue: (value: unknown) => {
+        if (!(typeof value === "string")) {
+          throw new Error(\`[BytesError] Invalid argument: \${typeof value}. Expected string.\`);
+        }
+        return base64ToUint8Array(value);
+      },
+      parseLiteral: (ast) => {
+        if (ast.kind !== Kind.STRING) {
+          throw new Error(\`[BytesError] Invalid argument: \${ast.kind}. Expected string.\`);
+        }
+        return base64ToUint8Array(ast.value);
+      }
+    });
+  `);
 }

--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -148,7 +148,7 @@ export function mapScalarToTypeGraphQLType(
       return "DecimalJSScalar";
     }
     case PrismaScalars.Bytes: {
-      return "GraphQLScalars.ByteResolver";
+      return "BytesScalar";
     }
     default: {
       throw new Error(`Unrecognized scalar type: ${scalar}`);

--- a/src/generator/imports.ts
+++ b/src/generator/imports.ts
@@ -52,7 +52,7 @@ export function generateGraphQLScalarsImport(sourceFile: SourceFile) {
 export function generateGraphQLScalarTypeImport(sourceFile: SourceFile) {
   sourceFile.addImportDeclaration({
     moduleSpecifier: "graphql",
-    namedImports: ["GraphQLScalarType"],
+    namedImports: ["GraphQLScalarType", "Kind"],
   });
 }
 

--- a/tests/regression/__snapshots__/inputs.ts.snap
+++ b/tests/regression/__snapshots__/inputs.ts.snap
@@ -3818,7 +3818,7 @@ exports[`inputs should properly generate input type classes for model with nativ
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { BytesScalar, DecimalJSScalar } from \"../../scalars\";
 
 @TypeGraphQL.InputType(\\"NativeTypeModelCreateInput\\", {})
 export class NativeTypeModelCreateInput {
@@ -3827,10 +3827,10 @@ export class NativeTypeModelCreateInput {
   })
   bigInt?: bigint | undefined;
 
-  @TypeGraphQL.Field(_type => GraphQLScalars.ByteResolver, {
+  @TypeGraphQL.Field(_type => BytesScalar, {
     nullable: true
   })
-  byteA?: Buffer | undefined;
+  byteA?: Uint8Array | undefined;
 
   @TypeGraphQL.Field(_type => DecimalJSScalar, {
     nullable: true
@@ -6176,25 +6176,25 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { BytesScalar, DecimalJSScalar } from \"../../scalars\";
 import { NestedBytesNullableFilter } from \\"../inputs/NestedBytesNullableFilter\\";
 
 @TypeGraphQL.InputType(\\"BytesNullableFilter\\", {})
 export class BytesNullableFilter {
-  @TypeGraphQL.Field(_type => GraphQLScalars.ByteResolver, {
+  @TypeGraphQL.Field(_type => BytesScalar, {
     nullable: true
   })
-  equals?: Buffer | undefined;
+  equals?: Uint8Array | undefined;
 
-  @TypeGraphQL.Field(_type => [GraphQLScalars.ByteResolver], {
+  @TypeGraphQL.Field(_type => [BytesScalar], {
     nullable: true
   })
-  in?: Buffer[] | undefined;
+  in?: Uint8Array[] | undefined;
 
-  @TypeGraphQL.Field(_type => [GraphQLScalars.ByteResolver], {
+  @TypeGraphQL.Field(_type => [BytesScalar], {
     nullable: true
   })
-  notIn?: Buffer[] | undefined;
+  notIn?: Uint8Array[] | undefined;
 
   @TypeGraphQL.Field(_type => NestedBytesNullableFilter, {
     nullable: true
@@ -6208,27 +6208,27 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { BytesScalar, DecimalJSScalar } from \"../../scalars\";
 import { NestedBytesNullableFilter } from \\"../inputs/NestedBytesNullableFilter\\";
 import { NestedBytesNullableWithAggregatesFilter } from \\"../inputs/NestedBytesNullableWithAggregatesFilter\\";
 import { NestedIntNullableFilter } from \\"../inputs/NestedIntNullableFilter\\";
 
 @TypeGraphQL.InputType(\\"BytesNullableWithAggregatesFilter\\", {})
 export class BytesNullableWithAggregatesFilter {
-  @TypeGraphQL.Field(_type => GraphQLScalars.ByteResolver, {
+  @TypeGraphQL.Field(_type => BytesScalar, {
     nullable: true
   })
-  equals?: Buffer | undefined;
+  equals?: Uint8Array | undefined;
 
-  @TypeGraphQL.Field(_type => [GraphQLScalars.ByteResolver], {
+  @TypeGraphQL.Field(_type => [BytesScalar], {
     nullable: true
   })
-  in?: Buffer[] | undefined;
+  in?: Uint8Array[] | undefined;
 
-  @TypeGraphQL.Field(_type => [GraphQLScalars.ByteResolver], {
+  @TypeGraphQL.Field(_type => [BytesScalar], {
     nullable: true
   })
-  notIn?: Buffer[] | undefined;
+  notIn?: Uint8Array[] | undefined;
 
   @TypeGraphQL.Field(_type => NestedBytesNullableWithAggregatesFilter, {
     nullable: true
@@ -6388,24 +6388,24 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { BytesScalar, DecimalJSScalar } from \"../../scalars\";
 
 @TypeGraphQL.InputType(\\"NestedBytesNullableFilter\\", {})
 export class NestedBytesNullableFilter {
-  @TypeGraphQL.Field(_type => GraphQLScalars.ByteResolver, {
+  @TypeGraphQL.Field(_type => BytesScalar, {
     nullable: true
   })
-  equals?: Buffer | undefined;
+  equals?: Uint8Array | undefined;
 
-  @TypeGraphQL.Field(_type => [GraphQLScalars.ByteResolver], {
+  @TypeGraphQL.Field(_type => [BytesScalar], {
     nullable: true
   })
-  in?: Buffer[] | undefined;
+  in?: Uint8Array[] | undefined;
 
-  @TypeGraphQL.Field(_type => [GraphQLScalars.ByteResolver], {
+  @TypeGraphQL.Field(_type => [BytesScalar], {
     nullable: true
   })
-  notIn?: Buffer[] | undefined;
+  notIn?: Uint8Array[] | undefined;
 
   @TypeGraphQL.Field(_type => NestedBytesNullableFilter, {
     nullable: true
@@ -6419,26 +6419,26 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { BytesScalar, DecimalJSScalar } from \"../../scalars\";
 import { NestedBytesNullableFilter } from \\"../inputs/NestedBytesNullableFilter\\";
 import { NestedIntNullableFilter } from \\"../inputs/NestedIntNullableFilter\\";
 
 @TypeGraphQL.InputType(\\"NestedBytesNullableWithAggregatesFilter\\", {})
 export class NestedBytesNullableWithAggregatesFilter {
-  @TypeGraphQL.Field(_type => GraphQLScalars.ByteResolver, {
+  @TypeGraphQL.Field(_type => BytesScalar, {
     nullable: true
   })
-  equals?: Buffer | undefined;
+  equals?: Uint8Array | undefined;
 
-  @TypeGraphQL.Field(_type => [GraphQLScalars.ByteResolver], {
+  @TypeGraphQL.Field(_type => [BytesScalar], {
     nullable: true
   })
-  in?: Buffer[] | undefined;
+  in?: Uint8Array[] | undefined;
 
-  @TypeGraphQL.Field(_type => [GraphQLScalars.ByteResolver], {
+  @TypeGraphQL.Field(_type => [BytesScalar], {
     nullable: true
   })
-  notIn?: Buffer[] | undefined;
+  notIn?: Uint8Array[] | undefined;
 
   @TypeGraphQL.Field(_type => NestedBytesNullableWithAggregatesFilter, {
     nullable: true
@@ -6632,14 +6632,14 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { BytesScalar, DecimalJSScalar } from \"../../scalars\";
 
 @TypeGraphQL.InputType(\\"NullableBytesFieldUpdateOperationsInput\\", {})
 export class NullableBytesFieldUpdateOperationsInput {
-  @TypeGraphQL.Field(_type => GraphQLScalars.ByteResolver, {
+  @TypeGraphQL.Field(_type => BytesScalar, {
     nullable: true
   })
-  set?: Buffer | undefined;
+  set?: Uint8Array | undefined;
 }
 "
 `;

--- a/tests/regression/__snapshots__/models.ts.snap
+++ b/tests/regression/__snapshots__/models.ts.snap
@@ -300,7 +300,7 @@ exports[`models should properly generate object type class for prisma model with
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../scalars\\";
+import { BytesScalar, DecimalJSScalar } from \"../scalars\";
 
 @TypeGraphQL.ObjectType(\\"NativeTypeModel\\", {})
 export class NativeTypeModel {
@@ -314,10 +314,10 @@ export class NativeTypeModel {
   })
   bigInt?: bigint | null;
 
-  @TypeGraphQL.Field(_type => GraphQLScalars.ByteResolver, {
+  @TypeGraphQL.Field(_type => BytesScalar, {
     nullable: true
   })
-  byteA?: Buffer | null;
+  byteA?: Uint8Array | null;
 
   @TypeGraphQL.Field(_type => DecimalJSScalar, {
     nullable: true


### PR DESCRIPTION
This commit updates the codebase to replace the use of `Buffer` with `Uint8Array` for the `Bytes` type, as required for compatibility with Prisma v6.

A custom GraphQL scalar, `BytesScalar`, has been introduced to handle the serialization and parsing of `Uint8Array` values. The code generator has been updated to use this new scalar, and all relevant test snapshots have been updated to reflect the changes.