### PR TITLE
feat: Prevent usage of reserved keywords as model names

### DIFF
--- a/src/generator/dmmf/dmmf-document.ts
+++ b/src/generator/dmmf/dmmf-document.ts
@@ -11,6 +11,8 @@ import {
 import { GeneratorOptions } from "../options";
 import { EmitBlockKind } from "../emit-block";
 
+const RESERVED_KEYWORDS: string[] = ["async", "await", "using"];
+
 export class DmmfDocument implements DMMF.Document {
   private models: DMMF.Model[];
   datamodel: DMMF.Datamodel;
@@ -28,6 +30,14 @@ export class DmmfDocument implements DMMF.Document {
       ...(schema.enumTypes.model ?? []),
     ];
     const models = [...datamodel.models, ...datamodel.types];
+
+    for (const model of models) {
+      if (RESERVED_KEYWORDS.includes(model.name)) {
+        throw new Error(
+          `Model name "${model.name}" is a reserved keyword. Please change it to a different name.`,
+        );
+      }
+    }
 
     // transform bare model without fields
     this.models = models.map(transformBareModel);

--- a/tests/regression/reserved-keywords.ts
+++ b/tests/regression/reserved-keywords.ts
@@ -1,0 +1,31 @@
+import generateArtifactsDirPath from "../helpers/artifacts-dir";
+import { generateCodeFromSchema } from "../helpers/generate-code";
+
+describe("reserved keywords", () => {
+  it.each(["await", "async", "using"])(
+    "should throw an error when model name is the reserved keyword '%s'",
+    async keyword => {
+      const schema = /* prisma */ `
+      model ${keyword} {
+        id Int @id
+      }
+    `;
+
+      let error: Error | undefined;
+      try {
+        await generateCodeFromSchema(schema, {
+          outputDirPath: generateArtifactsDirPath(
+            "dummy-dir-for-reserved-keywords",
+          ),
+        });
+      } catch (e) {
+        error = e as Error;
+      }
+
+      expect(error).toBeDefined();
+      expect(error!.message).toEqual(
+        `Model name "${keyword}" is a reserved keyword. Please change it to a different name.`,
+      );
+    },
+  );
+});


### PR DESCRIPTION
New keywords that can't be used as model names: async, await, using.

With this release, you can't use `async`, `await`, and `using` as model names anymore. This change adds a check to the DMMF document processing to throw an error if a model name is a reserved keyword.

A new regression test has been added to ensure that the error is thrown for each of the reserved keywords.