### PR TITLE
fix(generator): conditionally import BytesScalar

### DIFF
--- a/src/generator/imports.ts
+++ b/src/generator/imports.ts
@@ -56,12 +56,16 @@ export function generateGraphQLScalarTypeImport(sourceFile: SourceFile) {
   });
 }
 
-export function generateCustomScalarsImport(sourceFile: SourceFile, level = 0) {
+export function generateCustomScalarsImport(
+  sourceFile: SourceFile,
+  hasBytes: boolean,
+  level = 0,
+) {
   sourceFile.addImportDeclaration({
     moduleSpecifier:
       (level === 0 ? "./" : "") +
       path.posix.join(...Array(level).fill(".."), "scalars"),
-    namedImports: ["DecimalJSScalar", "BytesScalar"],
+    namedImports: ["DecimalJSScalar", ...(hasBytes ? ["BytesScalar"] : [])],
   });
 }
 

--- a/src/generator/model-type-class.ts
+++ b/src/generator/model-type-class.ts
@@ -37,7 +37,11 @@ export default function generateObjectTypeClassFromModel(
   generateTypeGraphQLImport(sourceFile);
   generateGraphQLScalarsImport(sourceFile);
   generatePrismaNamespaceImport(sourceFile, dmmfDocument.options, 1);
-  generateCustomScalarsImport(sourceFile, 1);
+  generateCustomScalarsImport(
+    sourceFile,
+    model.fields.some(field => field.type === "Bytes"),
+    1,
+  );
   generateModelsImports(
     sourceFile,
     model.fields

--- a/src/generator/type-class.ts
+++ b/src/generator/type-class.ts
@@ -51,7 +51,11 @@ export function generateOutputTypeClassFromType(
   generateTypeGraphQLImport(sourceFile);
   generateGraphQLScalarsImport(sourceFile);
   generatePrismaNamespaceImport(sourceFile, dmmfDocument.options, 2);
-  generateCustomScalarsImport(sourceFile, 2);
+  generateCustomScalarsImport(
+    sourceFile,
+    type.fields.some(field => field.outputType.type === "Bytes"),
+    2,
+  );
   generateArgsImports(sourceFile, fieldArgsTypeNames, 0);
   generateOutputsImports(
     sourceFile,
@@ -176,7 +180,11 @@ export function generateInputTypeClassFromType(
   generateTypeGraphQLImport(sourceFile);
   generateGraphQLScalarsImport(sourceFile);
   generatePrismaNamespaceImport(sourceFile, options, 2);
-  generateCustomScalarsImport(sourceFile, 2);
+  generateCustomScalarsImport(
+    sourceFile,
+    inputType.fields.some(field => field.selectedInputType.type === "Bytes"),
+    2,
+  );
   generateInputsImports(
     sourceFile,
     inputType.fields

--- a/tests/regression/__snapshots__/omit.ts.snap
+++ b/tests/regression/__snapshots__/omit.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`omit-fields when \`omitInputFieldsByDefault\` generator option is provided should properly generate input type class for prisma model without the omitted field: UserCreateInput 1`] = `
 "import * as TypeGraphQL from \\"type-graphql\\";


### PR DESCRIPTION
The `BytesScalar` was being imported unconditionally in all generated model and type files. This caused tests to fail when a model's `Bytes` fields were omitted, as the import would be unused.

This commit fixes the issue by making the `BytesScalar` import conditional. The `generateCustomScalarsImport` function now only adds the import if the model or type being generated actually contains a `Bytes` field.