### PR TITLE
test(regression): update snapshots for outputs.ts

### DIFF
--- a/tests/regression/__snapshots__/outputs.ts.snap
+++ b/tests/regression/__snapshots__/outputs.ts.snap
@@ -1,10 +1,10 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`outputs should properly generate aggregate classes for model with lowercase name: AggregateExample 1`] = `
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { ExampleAvgAggregate } from \\"../outputs/ExampleAvgAggregate\\";
 import { ExampleCountAggregate } from \\"../outputs/ExampleCountAggregate\\";
 import { ExampleMaxAggregate } from \\"../outputs/ExampleMaxAggregate\\";
@@ -45,7 +45,7 @@ exports[`outputs should properly generate aggregate classes for model with lower
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"CreateManyAndReturnExample\\", {})
 export class CreateManyAndReturnExample {
@@ -81,7 +81,7 @@ exports[`outputs should properly generate aggregate classes for model with lower
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"ExampleAvgAggregate\\", {})
 export class ExampleAvgAggregate {
@@ -102,7 +102,7 @@ exports[`outputs should properly generate aggregate classes for model with lower
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"ExampleCountAggregate\\", {})
 export class ExampleCountAggregate {
@@ -143,7 +143,7 @@ exports[`outputs should properly generate aggregate classes for model with lower
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"ExampleMaxAggregate\\", {})
 export class ExampleMaxAggregate {
@@ -179,7 +179,7 @@ exports[`outputs should properly generate aggregate classes for model with lower
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"ExampleMinAggregate\\", {})
 export class ExampleMinAggregate {
@@ -215,7 +215,7 @@ exports[`outputs should properly generate aggregate classes for model with lower
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"ExampleSumAggregate\\", {})
 export class ExampleSumAggregate {
@@ -242,6 +242,7 @@ export { ExampleGroupBy } from \\"./ExampleGroupBy\\";
 export { ExampleMaxAggregate } from \\"./ExampleMaxAggregate\\";
 export { ExampleMinAggregate } from \\"./ExampleMinAggregate\\";
 export { ExampleSumAggregate } from \\"./ExampleSumAggregate\\";
+export { UpdateManyexampleAndReturnOutputType } from \\"./UpdateManyexampleAndReturnOutputType\\";
 "
 `;
 
@@ -249,7 +250,7 @@ exports[`outputs should properly generate aggregate classes for renamed model: A
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { ExampleAvgAggregate } from \\"../outputs/ExampleAvgAggregate\\";
 import { ExampleCountAggregate } from \\"../outputs/ExampleCountAggregate\\";
 import { ExampleMaxAggregate } from \\"../outputs/ExampleMaxAggregate\\";
@@ -290,7 +291,7 @@ exports[`outputs should properly generate aggregate classes for renamed model: C
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"CreateManyAndReturnExample\\", {})
 export class CreateManyAndReturnExample {
@@ -326,7 +327,7 @@ exports[`outputs should properly generate aggregate classes for renamed model: E
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"ExampleAvgAggregate\\", {})
 export class ExampleAvgAggregate {
@@ -347,7 +348,7 @@ exports[`outputs should properly generate aggregate classes for renamed model: E
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"ExampleCountAggregate\\", {})
 export class ExampleCountAggregate {
@@ -388,7 +389,7 @@ exports[`outputs should properly generate aggregate classes for renamed model: E
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"ExampleMaxAggregate\\", {})
 export class ExampleMaxAggregate {
@@ -424,7 +425,7 @@ exports[`outputs should properly generate aggregate classes for renamed model: E
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"ExampleMinAggregate\\", {})
 export class ExampleMinAggregate {
@@ -460,7 +461,7 @@ exports[`outputs should properly generate aggregate classes for renamed model: E
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"ExampleSumAggregate\\", {})
 export class ExampleSumAggregate {
@@ -487,6 +488,7 @@ export { ExampleGroupBy } from \\"./ExampleGroupBy\\";
 export { ExampleMaxAggregate } from \\"./ExampleMaxAggregate\\";
 export { ExampleMinAggregate } from \\"./ExampleMinAggregate\\";
 export { ExampleSumAggregate } from \\"./ExampleSumAggregate\\";
+export { UpdateManySampleAndReturnOutputType } from \\"./UpdateManySampleAndReturnOutputType\\";
 "
 `;
 
@@ -494,7 +496,7 @@ exports[`outputs should properly generate count classes for relation fields with
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelCountSecondModelsFieldArgs } from \\"./args/FirstModelCountSecondModelsFieldArgs\\";
 
 @TypeGraphQL.ObjectType(\\"FirstModelCount\\", {})
@@ -531,6 +533,8 @@ export { SecondModelGroupBy } from \\"./SecondModelGroupBy\\";
 export { SecondModelMaxAggregate } from \\"./SecondModelMaxAggregate\\";
 export { SecondModelMinAggregate } from \\"./SecondModelMinAggregate\\";
 export { SecondModelSumAggregate } from \\"./SecondModelSumAggregate\\";
+export { UpdateManyFirstModelAndReturnOutputType } from \\"./UpdateManyFirstModelAndReturnOutputType\\";
+export { UpdateManySecondModelAndReturnOutputType } from \\"./UpdateManySecondModelAndReturnOutputType\\";
 export * from \\"./args\\";
 "
 `;
@@ -539,7 +543,7 @@ exports[`outputs should properly generate count classes for relation fields: Fir
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelCountSecondModelsFieldArgs } from \\"./args/FirstModelCountSecondModelsFieldArgs\\";
 
 @TypeGraphQL.ObjectType(\\"FirstModelCount\\", {})
@@ -576,6 +580,8 @@ export { SecondModelGroupBy } from \\"./SecondModelGroupBy\\";
 export { SecondModelMaxAggregate } from \\"./SecondModelMaxAggregate\\";
 export { SecondModelMinAggregate } from \\"./SecondModelMinAggregate\\";
 export { SecondModelSumAggregate } from \\"./SecondModelSumAggregate\\";
+export { UpdateManyFirstModelAndReturnOutputType } from \\"./UpdateManyFirstModelAndReturnOutputType\\";
+export { UpdateManySecondModelAndReturnOutputType } from \\"./UpdateManySecondModelAndReturnOutputType\\";
 export * from \\"./args\\";
 "
 `;
@@ -584,7 +590,7 @@ exports[`outputs should properly generate output type classes: AffectedRowsOutpu
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"AffectedRowsOutput\\", {})
 export class AffectedRowsOutput {
@@ -600,7 +606,7 @@ exports[`outputs should properly generate output type classes: AggregateSample 1
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SampleAvgAggregate } from \\"../outputs/SampleAvgAggregate\\";
 import { SampleCountAggregate } from \\"../outputs/SampleCountAggregate\\";
 import { SampleMaxAggregate } from \\"../outputs/SampleMaxAggregate\\";
@@ -641,7 +647,7 @@ exports[`outputs should properly generate output type classes: CreateManyAndRetu
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"CreateManyAndReturnSample\\", {})
 export class CreateManyAndReturnSample {
@@ -682,7 +688,7 @@ exports[`outputs should properly generate output type classes: SampleAvgAggregat
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"SampleAvgAggregate\\", {})
 export class SampleAvgAggregate {
@@ -708,7 +714,7 @@ exports[`outputs should properly generate output type classes: SampleCountAggreg
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"SampleCountAggregate\\", {})
 export class SampleCountAggregate {
@@ -754,7 +760,7 @@ exports[`outputs should properly generate output type classes: SampleGroupBy 1`]
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SampleAvgAggregate } from \\"../outputs/SampleAvgAggregate\\";
 import { SampleCountAggregate } from \\"../outputs/SampleCountAggregate\\";
 import { SampleMaxAggregate } from \\"../outputs/SampleMaxAggregate\\";
@@ -825,7 +831,7 @@ exports[`outputs should properly generate output type classes: SampleMaxAggregat
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"SampleMaxAggregate\\", {})
 export class SampleMaxAggregate {
@@ -861,7 +867,7 @@ exports[`outputs should properly generate output type classes: SampleMinAggregat
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"SampleMinAggregate\\", {})
 export class SampleMinAggregate {
@@ -897,7 +903,7 @@ exports[`outputs should properly generate output type classes: SampleSumAggregat
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"SampleSumAggregate\\", {})
 export class SampleSumAggregate {
@@ -929,6 +935,7 @@ export { SampleGroupBy } from \\"./SampleGroupBy\\";
 export { SampleMaxAggregate } from \\"./SampleMaxAggregate\\";
 export { SampleMinAggregate } from \\"./SampleMinAggregate\\";
 export { SampleSumAggregate } from \\"./SampleSumAggregate\\";
+export { UpdateManySampleAndReturnOutputType } from \\"./UpdateManySampleAndReturnOutputType\\";
 "
 `;
 
@@ -936,7 +943,7 @@ exports[`outputs when \`emitIsAbstract\` generator option is enabled should prop
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelCountSecondModelsFieldArgs } from \\"./args/FirstModelCountSecondModelsFieldArgs\\";
 
 @TypeGraphQL.ObjectType(\\"FirstModelCount\\", {
@@ -960,7 +967,7 @@ exports[`outputs when customPrismaImportPath option is set should properly gener
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../test/import\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SampleAvgAggregate } from \\"../outputs/SampleAvgAggregate\\";
 import { SampleCountAggregate } from \\"../outputs/SampleCountAggregate\\";
 import { SampleMaxAggregate } from \\"../outputs/SampleMaxAggregate\\";
@@ -1001,7 +1008,7 @@ exports[`outputs when simpleResolvers option is enabled should properly generate
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"AffectedRowsOutput\\", {
   simpleResolvers: true
@@ -1019,7 +1026,7 @@ exports[`outputs when simpleResolvers option is enabled should properly generate
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SampleAvgAggregate } from \\"../outputs/SampleAvgAggregate\\";
 import { SampleCountAggregate } from \\"../outputs/SampleCountAggregate\\";
 import { SampleMaxAggregate } from \\"../outputs/SampleMaxAggregate\\";
@@ -1062,7 +1069,7 @@ exports[`outputs when simpleResolvers option is enabled should properly generate
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.ObjectType(\\"SampleAvgAggregate\\", {
   simpleResolvers: true


### PR DESCRIPTION
The tests in `tests/regression/outputs.ts` were failing due to outdated snapshots. This change updates the snapshots to match the new, correct output of the code generator.