### PR TITLE
fix(generator): conditionally generate Bytes scalar

### DIFF
--- a/src/generator/dmmf/dmmf-document.ts
+++ b/src/generator/dmmf/dmmf-document.ts
@@ -20,6 +20,7 @@ export class DmmfDocument implements DMMF.Document {
   enums: DMMF.Enum[];
   modelMappings: DMMF.ModelMapping[];
   relationModels: DMMF.RelationModel[];
+  scalarTypeNames: string[];
 
   constructor(
     { datamodel, schema, mappings }: PrismaDMMF.Document,
@@ -85,6 +86,28 @@ export class DmmfDocument implements DMMF.Document {
         );
       })
       .map(generateRelationModel(this));
+
+    const scalarTypes = new Set<string>();
+    this.schema.inputTypes.forEach(inputType =>
+      inputType.fields.forEach(field => {
+        if (field.kind === "scalar") {
+          scalarTypes.add(field.type);
+        }
+      }),
+    );
+    this.schema.outputTypes.forEach(outputType =>
+      outputType.fields.forEach(field => {
+        if (field.kind === "scalar") {
+          scalarTypes.add(field.type);
+        }
+        field.args.forEach(arg => {
+          if (arg.kind === "scalar") {
+            scalarTypes.add(arg.type);
+          }
+        });
+      }),
+    );
+    this.scalarTypeNames = [...scalarTypes];
   }
 
   getModelTypeName(modelName: string): string | undefined {

--- a/src/generator/generate-code.ts
+++ b/src/generator/generate-code.ts
@@ -506,7 +506,7 @@ export default async function generateCode(
     undefined,
     { overwrite: true },
   );
-  generateCustomScalars(scalarsSourceFile, dmmfDocument.options);
+  generateCustomScalars(scalarsSourceFile, dmmfDocument);
 
   log("Generate custom helpers");
   const helpersSourceFile = project.createSourceFile(

--- a/src/generator/generate-scalars.ts
+++ b/src/generator/generate-scalars.ts
@@ -1,17 +1,19 @@
 import { SourceFile } from "ts-morph";
+import { DmmfDocument } from "./dmmf/dmmf-document";
 import {
   generateGraphQLScalarTypeImport,
   generatePrismaNamespaceImport,
 } from "./imports";
 
-import { GeneratorOptions } from "./options";
-
 export function generateCustomScalars(
   sourceFile: SourceFile,
-  options: GeneratorOptions,
+  dmmfDocument: DmmfDocument,
 ) {
-  generatePrismaNamespaceImport(sourceFile, options);
-  generateGraphQLScalarTypeImport(sourceFile);
+  generatePrismaNamespaceImport(sourceFile, dmmfDocument.options);
+  generateGraphQLScalarTypeImport(
+    sourceFile,
+    dmmfDocument.scalarTypeNames.includes("Bytes"),
+  );
 
   sourceFile.addStatements(/* ts */ `
     export const DecimalJSScalar = new GraphQLScalarType({
@@ -32,36 +34,38 @@ export function generateCustomScalars(
     });
   `);
 
-  sourceFile.addStatements(/* ts */ `
-    function uint8ArrayToBase64(uint8Array: Uint8Array) {
-      return Buffer.from(uint8Array).toString("base64");
-    }
-
-    function base64ToUint8Array(base64: string) {
-      return new Uint8Array(Buffer.from(base64, "base64"));
-    }
-
-    export const BytesScalar = new GraphQLScalarType({
-      name: "Bytes",
-      description: "GraphQL Scalar representing the Prisma.Bytes type.",
-      serialize: (value: unknown) => {
-        if (!(value instanceof Uint8Array)) {
-          throw new Error(\`[BytesError] Invalid argument: \${Object.prototype.toString.call(value)}. Expected Uint8Array.\`);
-        }
-        return uint8ArrayToBase64(value);
-      },
-      parseValue: (value: unknown) => {
-        if (!(typeof value === "string")) {
-          throw new Error(\`[BytesError] Invalid argument: \${typeof value}. Expected string.\`);
-        }
-        return base64ToUint8Array(value);
-      },
-      parseLiteral: (ast) => {
-        if (ast.kind !== Kind.STRING) {
-          throw new Error(\`[BytesError] Invalid argument: \${ast.kind}. Expected string.\`);
-        }
-        return base64ToUint8Array(ast.value);
+  if (dmmfDocument.scalarTypeNames.includes("Bytes")) {
+    sourceFile.addStatements(/* ts */ `
+      function uint8ArrayToBase64(uint8Array: Uint8Array) {
+        return Buffer.from(uint8Array).toString("base64");
       }
-    });
-  `);
+
+      function base64ToUint8Array(base64: string) {
+        return new Uint8Array(Buffer.from(base64, "base64"));
+      }
+
+      export const BytesScalar = new GraphQLScalarType({
+        name: "Bytes",
+        description: "GraphQL Scalar representing the Prisma.Bytes type.",
+        serialize: (value: unknown) => {
+          if (!(value instanceof Uint8Array)) {
+            throw new Error(\`[BytesError] Invalid argument: \${Object.prototype.toString.call(value)}. Expected Uint8Array.\`);
+          }
+          return uint8ArrayToBase64(value);
+        },
+        parseValue: (value: unknown) => {
+          if (!(typeof value === "string")) {
+            throw new Error(\`[BytesError] Invalid argument: \${typeof value}. Expected string.\`);
+          }
+          return base64ToUint8Array(value);
+        },
+        parseLiteral: (ast) => {
+          if (ast.kind !== Kind.STRING) {
+            throw new Error(\`[BytesError] Invalid argument: \${ast.kind}. Expected string.\`);
+          }
+          return base64ToUint8Array(ast.value);
+        }
+      });
+    `);
+  }
 }

--- a/src/generator/imports.ts
+++ b/src/generator/imports.ts
@@ -49,10 +49,13 @@ export function generateGraphQLScalarsImport(sourceFile: SourceFile) {
   });
 }
 
-export function generateGraphQLScalarTypeImport(sourceFile: SourceFile) {
+export function generateGraphQLScalarTypeImport(
+  sourceFile: SourceFile,
+  hasBytes: boolean,
+) {
   sourceFile.addImportDeclaration({
     moduleSpecifier: "graphql",
-    namedImports: ["GraphQLScalarType", "Kind"],
+    namedImports: ["GraphQLScalarType", ...(hasBytes ? ["Kind"] : [])],
   });
 }
 

--- a/tests/regression/__snapshots__/generate-scalars.ts.snap
+++ b/tests/regression/__snapshots__/generate-scalars.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`custom scalars should properly emit custom scalars file: mainIndex 1`] = `
 "import * as crudResolversImport from \\"./resolvers/crud/resolvers-crud.index\\";


### PR DESCRIPTION
The `generate-scalars.ts` test was failing due to a snapshot mismatch. The `BytesScalar` was being generated unconditionally, even when the schema did not include a `Bytes` type.

This commit fixes the issue by making the generation of `BytesScalar` conditional. The `DmmfDocument` class now collects all scalar type names from the schema and stores them in a `scalarTypeNames` property. The `generateCustomScalars` function uses this property to check if the `Bytes` type is present in the schema before generating the corresponding scalar.