### PR TITLE
fix(generator): Correctly parse ScalarRelationFilter input type names

### DIFF
--- a/src/generator/helpers.ts
+++ b/src/generator/helpers.ts
@@ -179,6 +179,7 @@ function getInputKeywordPhrasePosition(inputTypeName: string) {
     "ScalarWhere",
     "Where",
     "ListRelationFilter",
+    "ScalarRelationFilter",
     "RelationFilter",
     "Filter",
   ]

--- a/tests/regression/__snapshots__/inputs.ts.snap
+++ b/tests/regression/__snapshots__/inputs.ts.snap
@@ -1,10 +1,10 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`inputs should generate proper ScalarWhereWithAggregatesInput for model: SampleScalarWhereWithAggregatesInput 1`] = `
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { BoolWithAggregatesFilter } from \\"../inputs/BoolWithAggregatesFilter\\";
 import { DateTimeWithAggregatesFilter } from \\"../inputs/DateTimeWithAggregatesFilter\\";
 import { FloatWithAggregatesFilter } from \\"../inputs/FloatWithAggregatesFilter\\";
@@ -71,7 +71,7 @@ exports[`inputs should generate proper WithAggregatesFilter for scalars: BoolWit
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedBoolFilter } from \\"../inputs/NestedBoolFilter\\";
 import { NestedBoolWithAggregatesFilter } from \\"../inputs/NestedBoolWithAggregatesFilter\\";
 import { NestedIntFilter } from \\"../inputs/NestedIntFilter\\";
@@ -110,7 +110,7 @@ exports[`inputs should generate proper WithAggregatesFilter for scalars: DateTim
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedDateTimeFilter } from \\"../inputs/NestedDateTimeFilter\\";
 import { NestedDateTimeWithAggregatesFilter } from \\"../inputs/NestedDateTimeWithAggregatesFilter\\";
 import { NestedIntFilter } from \\"../inputs/NestedIntFilter\\";
@@ -179,7 +179,7 @@ exports[`inputs should generate proper WithAggregatesFilter for scalars: FloatWi
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedFloatFilter } from \\"../inputs/NestedFloatFilter\\";
 import { NestedFloatWithAggregatesFilter } from \\"../inputs/NestedFloatWithAggregatesFilter\\";
 import { NestedIntFilter } from \\"../inputs/NestedIntFilter\\";
@@ -258,7 +258,7 @@ exports[`inputs should generate proper WithAggregatesFilter for scalars: IntWith
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedFloatFilter } from \\"../inputs/NestedFloatFilter\\";
 import { NestedIntFilter } from \\"../inputs/NestedIntFilter\\";
 import { NestedIntWithAggregatesFilter } from \\"../inputs/NestedIntWithAggregatesFilter\\";
@@ -337,9 +337,10 @@ exports[`inputs should generate proper WithAggregatesFilter for scalars: JsonWit
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedIntFilter } from \\"../inputs/NestedIntFilter\\";
 import { NestedJsonFilter } from \\"../inputs/NestedJsonFilter\\";
+import { QueryMode } from \\"../../enums/QueryMode\\";
 
 @TypeGraphQL.InputType(\\"JsonWithAggregatesFilter\\", {})
 export class JsonWithAggregatesFilter {
@@ -352,6 +353,11 @@ export class JsonWithAggregatesFilter {
     nullable: true
   })
   path?: string[] | undefined;
+
+  @TypeGraphQL.Field(_type => QueryMode, {
+    nullable: true
+  })
+  mode?: \\"default\\" | \\"insensitive\\" | undefined;
 
   @TypeGraphQL.Field(_type => String, {
     nullable: true
@@ -371,17 +377,17 @@ export class JsonWithAggregatesFilter {
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
-  array_contains?: Prisma.InputJsonValue | undefined;
-
-  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
-    nullable: true
-  })
   array_starts_with?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
   array_ends_with?: Prisma.InputJsonValue | undefined;
+
+  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
+    nullable: true
+  })
+  array_contains?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
@@ -430,7 +436,7 @@ exports[`inputs should generate proper WithAggregatesFilter for scalars: StringW
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedIntFilter } from \\"../inputs/NestedIntFilter\\";
 import { NestedStringFilter } from \\"../inputs/NestedStringFilter\\";
 import { NestedStringWithAggregatesFilter } from \\"../inputs/NestedStringWithAggregatesFilter\\";
@@ -566,7 +572,7 @@ exports[`inputs should properly generate input type class for filtering by enums
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedEnumColorFilter } from \\"../inputs/NestedEnumColorFilter\\";
 import { Color } from \\"../../enums/Color\\";
 
@@ -599,7 +605,7 @@ exports[`inputs should properly generate input type class for filtering by enums
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { Color } from \\"../../enums/Color\\";
 
 @TypeGraphQL.InputType(\\"NestedEnumColorFilter\\", {})
@@ -660,7 +666,7 @@ exports[`inputs should properly generate input type classes for connectOrCreate:
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { UserCreateOrConnectWithoutPostsFieldInput } from \\"../inputs/UserCreateOrConnectWithoutPostsFieldInput\\";
 import { UserCreateWithoutPostsFieldInput } from \\"../inputs/UserCreateWithoutPostsFieldInput\\";
 import { UserWhereUniqueInput } from \\"../inputs/UserWhereUniqueInput\\";
@@ -689,7 +695,7 @@ exports[`inputs should properly generate input type classes for connectOrCreate:
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { UserCreateWithoutPostsFieldInput } from \\"../inputs/UserCreateWithoutPostsFieldInput\\";
 import { UserWhereUniqueInput } from \\"../inputs/UserWhereUniqueInput\\";
 
@@ -712,7 +718,7 @@ exports[`inputs should properly generate input type classes for connectOrCreate:
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { UserCreateOrConnectWithoutPostsFieldInput } from \\"../inputs/UserCreateOrConnectWithoutPostsFieldInput\\";
 import { UserCreateWithoutPostsFieldInput } from \\"../inputs/UserCreateWithoutPostsFieldInput\\";
 import { UserUpdateToOneWithWhereWithoutPostsFieldInput } from \\"../inputs/UserUpdateToOneWithWhereWithoutPostsFieldInput\\";
@@ -753,7 +759,7 @@ exports[`inputs should properly generate input type classes for creating models 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SampleModelCreateintArrayFieldInput } from \\"../inputs/SampleModelCreateintArrayFieldInput\\";
 import { SampleModelCreatestringArrayFieldInput } from \\"../inputs/SampleModelCreatestringArrayFieldInput\\";
 import { Color } from \\"../../enums/Color\\";
@@ -847,7 +853,7 @@ exports[`inputs should properly generate input type classes for creating models 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SampleModelCreateintArrayFieldInput } from \\"../inputs/SampleModelCreateintArrayFieldInput\\";
 import { SampleModelCreatestringArrayFieldInput } from \\"../inputs/SampleModelCreatestringArrayFieldInput\\";
 import { Color } from \\"../../enums/Color\\";
@@ -946,7 +952,7 @@ exports[`inputs should properly generate input type classes for creating models 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"SampleModelCreateintArrayFieldInput\\", {})
 export class SampleModelCreateintArrayFieldInput {
@@ -962,7 +968,7 @@ exports[`inputs should properly generate input type classes for creating models 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"SampleModelCreatestringArrayFieldInput\\", {})
 export class SampleModelCreatestringArrayFieldInput {
@@ -1069,7 +1075,8 @@ exports[`inputs should properly generate input type classes for filtering json f
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
+import { QueryMode } from \\"../../enums/QueryMode\\";
 
 @TypeGraphQL.InputType(\\"JsonFilter\\", {})
 export class JsonFilter {
@@ -1082,6 +1089,11 @@ export class JsonFilter {
     nullable: true
   })
   path?: string[] | undefined;
+
+  @TypeGraphQL.Field(_type => QueryMode, {
+    nullable: true
+  })
+  mode?: \\"default\\" | \\"insensitive\\" | undefined;
 
   @TypeGraphQL.Field(_type => String, {
     nullable: true
@@ -1101,17 +1113,17 @@ export class JsonFilter {
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
-  array_contains?: Prisma.InputJsonValue | undefined;
-
-  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
-    nullable: true
-  })
   array_starts_with?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
   array_ends_with?: Prisma.InputJsonValue | undefined;
+
+  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
+    nullable: true
+  })
+  array_contains?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
@@ -1145,9 +1157,10 @@ exports[`inputs should properly generate input type classes for filtering json f
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedIntFilter } from \\"../inputs/NestedIntFilter\\";
 import { NestedJsonFilter } from \\"../inputs/NestedJsonFilter\\";
+import { QueryMode } from \\"../../enums/QueryMode\\";
 
 @TypeGraphQL.InputType(\\"JsonWithAggregatesFilter\\", {})
 export class JsonWithAggregatesFilter {
@@ -1160,6 +1173,11 @@ export class JsonWithAggregatesFilter {
     nullable: true
   })
   path?: string[] | undefined;
+
+  @TypeGraphQL.Field(_type => QueryMode, {
+    nullable: true
+  })
+  mode?: \\"default\\" | \\"insensitive\\" | undefined;
 
   @TypeGraphQL.Field(_type => String, {
     nullable: true
@@ -1179,17 +1197,17 @@ export class JsonWithAggregatesFilter {
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
-  array_contains?: Prisma.InputJsonValue | undefined;
-
-  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
-    nullable: true
-  })
   array_starts_with?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
   array_ends_with?: Prisma.InputJsonValue | undefined;
+
+  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
+    nullable: true
+  })
+  array_contains?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
@@ -1238,7 +1256,8 @@ exports[`inputs should properly generate input type classes for filtering json f
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
+import { QueryMode } from \\"../../enums/QueryMode\\";
 
 @TypeGraphQL.InputType(\\"NestedJsonFilter\\", {})
 export class NestedJsonFilter {
@@ -1251,6 +1270,11 @@ export class NestedJsonFilter {
     nullable: true
   })
   path?: string[] | undefined;
+
+  @TypeGraphQL.Field(_type => QueryMode, {
+    nullable: true
+  })
+  mode?: \\"default\\" | \\"insensitive\\" | undefined;
 
   @TypeGraphQL.Field(_type => String, {
     nullable: true
@@ -1270,17 +1294,17 @@ export class NestedJsonFilter {
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
-  array_contains?: Prisma.InputJsonValue | undefined;
-
-  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
-    nullable: true
-  })
   array_starts_with?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
   array_ends_with?: Prisma.InputJsonValue | undefined;
+
+  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
+    nullable: true
+  })
+  array_contains?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
@@ -1360,7 +1384,7 @@ exports[`inputs should properly generate input type classes for filtering models
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { BoolFilter } from \\"../inputs/BoolFilter\\";
 import { DateTimeFilter } from \\"../inputs/DateTimeFilter\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
@@ -1433,7 +1457,7 @@ exports[`inputs should properly generate input type classes for filtering models
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { BoolFilter } from \\"../inputs/BoolFilter\\";
 import { DateTimeFilter } from \\"../inputs/DateTimeFilter\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
@@ -1559,7 +1583,7 @@ exports[`inputs should properly generate input type classes for filtering models
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SecondModelOrderByRelationAggregateInput } from \\"../inputs/SecondModelOrderByRelationAggregateInput\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
@@ -1592,7 +1616,7 @@ exports[`inputs should properly generate input type classes for filtering models
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
 import { StringFilter } from \\"../inputs/StringFilter\\";
@@ -1636,7 +1660,7 @@ exports[`inputs should properly generate input type classes for filtering models
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
 import { SecondModelListRelationFilter } from \\"../inputs/SecondModelListRelationFilter\\";
@@ -1686,7 +1710,7 @@ exports[`inputs should properly generate input type classes for filtering models
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelWhereInput } from \\"../inputs/FirstModelWhereInput\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { SecondModelListRelationFilter } from \\"../inputs/SecondModelListRelationFilter\\";
@@ -1804,7 +1828,7 @@ exports[`inputs should properly generate input type classes for filtering models
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SecondModelOrderByRelationAggregateInput } from \\"../inputs/SecondModelOrderByRelationAggregateInput\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
@@ -1833,33 +1857,11 @@ export class FirstModelOrderByWithRelationInput {
 "
 `;
 
-exports[`inputs should properly generate input type classes for filtering models by one to many relation fields: FirstModelRelationFilter 1`] = `
-"import * as TypeGraphQL from \\"type-graphql\\";
-import * as GraphQLScalars from \\"graphql-scalars\\";
-import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
-import { FirstModelWhereInput } from \\"../inputs/FirstModelWhereInput\\";
-
-@TypeGraphQL.InputType(\\"FirstModelRelationFilter\\", {})
-export class FirstModelRelationFilter {
-  @TypeGraphQL.Field(_type => FirstModelWhereInput, {
-    nullable: true
-  })
-  is?: FirstModelWhereInput | undefined;
-
-  @TypeGraphQL.Field(_type => FirstModelWhereInput, {
-    nullable: true
-  })
-  isNot?: FirstModelWhereInput | undefined;
-}
-"
-`;
-
 exports[`inputs should properly generate input type classes for filtering models by one to many relation fields: FirstModelWhereInput 1`] = `
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
 import { SecondModelListRelationFilter } from \\"../inputs/SecondModelListRelationFilter\\";
@@ -1909,7 +1911,7 @@ exports[`inputs should properly generate input type classes for filtering models
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelWhereInput } from \\"../inputs/FirstModelWhereInput\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { SecondModelListRelationFilter } from \\"../inputs/SecondModelListRelationFilter\\";
@@ -1958,7 +1960,7 @@ exports[`inputs should properly generate input type classes for filtering models
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SecondModelWhereInput } from \\"../inputs/SecondModelWhereInput\\";
 
 @TypeGraphQL.InputType(\\"SecondModelListRelationFilter\\", {})
@@ -1985,7 +1987,7 @@ exports[`inputs should properly generate input type classes for filtering models
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelOrderByWithRelationInput } from \\"../inputs/FirstModelOrderByWithRelationInput\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
@@ -2023,7 +2025,7 @@ exports[`inputs should properly generate input type classes for filtering models
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
 import { StringFilter } from \\"../inputs/StringFilter\\";
@@ -2072,8 +2074,8 @@ exports[`inputs should properly generate input type classes for filtering models
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
-import { FirstModelRelationFilter } from \\"../inputs/FirstModelRelationFilter\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
+import { FirstModelScalarRelationFilter } from \\"../inputs/FirstModelScalarRelationFilter\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
 import { StringFilter } from \\"../inputs/StringFilter\\";
@@ -2115,10 +2117,10 @@ export class SecondModelWhereInput {
   })
   firstModelFieldId?: IntFilter | undefined;
 
-  @TypeGraphQL.Field(_type => FirstModelRelationFilter, {
+  @TypeGraphQL.Field(_type => FirstModelScalarRelationFilter, {
     nullable: true
   })
-  firstModelField?: FirstModelRelationFilter | undefined;
+  firstModelField?: FirstModelScalarRelationFilter | undefined;
 }
 "
 `;
@@ -2127,8 +2129,8 @@ exports[`inputs should properly generate input type classes for filtering models
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
-import { FirstModelRelationFilter } from \\"../inputs/FirstModelRelationFilter\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
+import { FirstModelScalarRelationFilter } from \\"../inputs/FirstModelScalarRelationFilter\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
 import { SecondModelWhereInput } from \\"../inputs/SecondModelWhereInput\\";
@@ -2170,10 +2172,10 @@ export class SecondModelWhereUniqueInput {
   })
   firstModelFieldId?: IntFilter | undefined;
 
-  @TypeGraphQL.Field(_type => FirstModelRelationFilter, {
+  @TypeGraphQL.Field(_type => FirstModelScalarRelationFilter, {
     nullable: true
   })
-  firstModelField?: FirstModelRelationFilter | undefined;
+  firstModelField?: FirstModelScalarRelationFilter | undefined;
 }
 "
 `;
@@ -2190,7 +2192,7 @@ export { FirstModelMaxOrderByAggregateInput } from \\"./FirstModelMaxOrderByAggr
 export { FirstModelMinOrderByAggregateInput } from \\"./FirstModelMinOrderByAggregateInput\\";
 export { FirstModelOrderByWithAggregationInput } from \\"./FirstModelOrderByWithAggregationInput\\";
 export { FirstModelOrderByWithRelationInput } from \\"./FirstModelOrderByWithRelationInput\\";
-export { FirstModelRelationFilter } from \\"./FirstModelRelationFilter\\";
+export { FirstModelScalarRelationFilter } from \\"./FirstModelScalarRelationFilter\\";
 export { FirstModelScalarWhereWithAggregatesInput } from \\"./FirstModelScalarWhereWithAggregatesInput\\";
 export { FirstModelSumOrderByAggregateInput } from \\"./FirstModelSumOrderByAggregateInput\\";
 export { FirstModelUpdateInput } from \\"./FirstModelUpdateInput\\";
@@ -2250,7 +2252,7 @@ exports[`inputs should properly generate input type classes for filtering scalar
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedBoolFilter } from \\"../inputs/NestedBoolFilter\\";
 
 @TypeGraphQL.InputType(\\"BoolFilter\\", {})
@@ -2272,7 +2274,7 @@ exports[`inputs should properly generate input type classes for filtering scalar
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedDateTimeFilter } from \\"../inputs/NestedDateTimeFilter\\";
 
 @TypeGraphQL.InputType(\\"DateTimeFilter\\", {})
@@ -2324,7 +2326,7 @@ exports[`inputs should properly generate input type classes for filtering scalar
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedFloatFilter } from \\"../inputs/NestedFloatFilter\\";
 
 @TypeGraphQL.InputType(\\"FloatFilter\\", {})
@@ -2376,7 +2378,7 @@ exports[`inputs should properly generate input type classes for filtering scalar
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedIntFilter } from \\"../inputs/NestedIntFilter\\";
 
 @TypeGraphQL.InputType(\\"IntFilter\\", {})
@@ -2428,7 +2430,7 @@ exports[`inputs should properly generate input type classes for filtering scalar
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"IntNullableListFilter\\", {})
 export class IntNullableListFilter {
@@ -2464,7 +2466,8 @@ exports[`inputs should properly generate input type classes for filtering scalar
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
+import { QueryMode } from \\"../../enums/QueryMode\\";
 
 @TypeGraphQL.InputType(\\"JsonFilter\\", {})
 export class JsonFilter {
@@ -2477,6 +2480,11 @@ export class JsonFilter {
     nullable: true
   })
   path?: string[] | undefined;
+
+  @TypeGraphQL.Field(_type => QueryMode, {
+    nullable: true
+  })
+  mode?: \\"default\\" | \\"insensitive\\" | undefined;
 
   @TypeGraphQL.Field(_type => String, {
     nullable: true
@@ -2496,17 +2504,17 @@ export class JsonFilter {
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
-  array_contains?: Prisma.InputJsonValue | undefined;
-
-  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
-    nullable: true
-  })
   array_starts_with?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
   array_ends_with?: Prisma.InputJsonValue | undefined;
+
+  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
+    nullable: true
+  })
+  array_contains?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
@@ -2540,7 +2548,7 @@ exports[`inputs should properly generate input type classes for filtering scalar
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"NestedBoolFilter\\", {})
 export class NestedBoolFilter {
@@ -2561,7 +2569,7 @@ exports[`inputs should properly generate input type classes for filtering scalar
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"NestedDateTimeFilter\\", {})
 export class NestedDateTimeFilter {
@@ -2612,7 +2620,7 @@ exports[`inputs should properly generate input type classes for filtering scalar
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"NestedFloatFilter\\", {})
 export class NestedFloatFilter {
@@ -2663,7 +2671,7 @@ exports[`inputs should properly generate input type classes for filtering scalar
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"NestedIntFilter\\", {})
 export class NestedIntFilter {
@@ -2714,7 +2722,8 @@ exports[`inputs should properly generate input type classes for filtering scalar
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
+import { QueryMode } from \\"../../enums/QueryMode\\";
 
 @TypeGraphQL.InputType(\\"NestedJsonFilter\\", {})
 export class NestedJsonFilter {
@@ -2727,6 +2736,11 @@ export class NestedJsonFilter {
     nullable: true
   })
   path?: string[] | undefined;
+
+  @TypeGraphQL.Field(_type => QueryMode, {
+    nullable: true
+  })
+  mode?: \\"default\\" | \\"insensitive\\" | undefined;
 
   @TypeGraphQL.Field(_type => String, {
     nullable: true
@@ -2746,17 +2760,17 @@ export class NestedJsonFilter {
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
-  array_contains?: Prisma.InputJsonValue | undefined;
-
-  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
-    nullable: true
-  })
   array_starts_with?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
   })
   array_ends_with?: Prisma.InputJsonValue | undefined;
+
+  @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
+    nullable: true
+  })
+  array_contains?: Prisma.InputJsonValue | undefined;
 
   @TypeGraphQL.Field(_type => GraphQLScalars.JSONResolver, {
     nullable: true
@@ -2790,7 +2804,7 @@ exports[`inputs should properly generate input type classes for filtering scalar
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"NestedStringNullableFilter\\", {})
 export class NestedStringNullableFilter {
@@ -2856,7 +2870,7 @@ exports[`inputs should properly generate input type classes for filtering scalar
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedStringFilter } from \\"../inputs/NestedStringFilter\\";
 import { QueryMode } from \\"../../enums/QueryMode\\";
 
@@ -2929,7 +2943,7 @@ exports[`inputs should properly generate input type classes for filtering scalar
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedStringNullableFilter } from \\"../inputs/NestedStringNullableFilter\\";
 import { QueryMode } from \\"../../enums/QueryMode\\";
 
@@ -3002,7 +3016,7 @@ exports[`inputs should properly generate input type classes for filtering scalar
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"StringNullableListFilter\\", {})
 export class StringNullableListFilter {
@@ -3119,7 +3133,7 @@ exports[`inputs should properly generate input type classes for inserting many e
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"FirstModelCreateManyInput\\", {})
 export class FirstModelCreateManyInput {
@@ -3145,7 +3159,7 @@ exports[`inputs should properly generate input type classes for inserting many e
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"SecondModelCreateManyFirstModelFieldInput\\", {})
 export class SecondModelCreateManyFirstModelFieldInput {
@@ -3171,7 +3185,7 @@ exports[`inputs should properly generate input type classes for inserting many e
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SecondModelCreateManyFirstModelFieldInput } from \\"../inputs/SecondModelCreateManyFirstModelFieldInput\\";
 
 @TypeGraphQL.InputType(\\"SecondModelCreateManyFirstModelFieldInputEnvelope\\", {})
@@ -3193,7 +3207,7 @@ exports[`inputs should properly generate input type classes for inserting many e
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"SecondModelCreateManyInput\\", {})
 export class SecondModelCreateManyInput {
@@ -3232,7 +3246,7 @@ export { FirstModelMaxOrderByAggregateInput } from \\"./FirstModelMaxOrderByAggr
 export { FirstModelMinOrderByAggregateInput } from \\"./FirstModelMinOrderByAggregateInput\\";
 export { FirstModelOrderByWithAggregationInput } from \\"./FirstModelOrderByWithAggregationInput\\";
 export { FirstModelOrderByWithRelationInput } from \\"./FirstModelOrderByWithRelationInput\\";
-export { FirstModelRelationFilter } from \\"./FirstModelRelationFilter\\";
+export { FirstModelScalarRelationFilter } from \\"./FirstModelScalarRelationFilter\\";
 export { FirstModelScalarWhereWithAggregatesInput } from \\"./FirstModelScalarWhereWithAggregatesInput\\";
 export { FirstModelSumOrderByAggregateInput } from \\"./FirstModelSumOrderByAggregateInput\\";
 export { FirstModelUpdateInput } from \\"./FirstModelUpdateInput\\";
@@ -3292,7 +3306,7 @@ exports[`inputs should properly generate input type classes for model with compo
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"DirectorFirstNameLastNameCompoundUniqueInput\\", {})
 export class DirectorFirstNameLastNameCompoundUniqueInput {
@@ -3313,7 +3327,7 @@ exports[`inputs should properly generate input type classes for model with compo
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { MovieOrderByRelationAggregateInput } from \\"../inputs/MovieOrderByRelationAggregateInput\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
@@ -3346,7 +3360,7 @@ exports[`inputs should properly generate input type classes for model with compo
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
 import { MovieListRelationFilter } from \\"../inputs/MovieListRelationFilter\\";
 import { StringFilter } from \\"../inputs/StringFilter\\";
@@ -3395,7 +3409,7 @@ exports[`inputs should properly generate input type classes for model with compo
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { DirectorFirstNameLastNameCompoundUniqueInput } from \\"../inputs/DirectorFirstNameLastNameCompoundUniqueInput\\";
 import { DirectorWhereInput } from \\"../inputs/DirectorWhereInput\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
@@ -3460,7 +3474,7 @@ export { DirectorMaxOrderByAggregateInput } from \\"./DirectorMaxOrderByAggregat
 export { DirectorMinOrderByAggregateInput } from \\"./DirectorMinOrderByAggregateInput\\";
 export { DirectorOrderByWithAggregationInput } from \\"./DirectorOrderByWithAggregationInput\\";
 export { DirectorOrderByWithRelationInput } from \\"./DirectorOrderByWithRelationInput\\";
-export { DirectorRelationFilter } from \\"./DirectorRelationFilter\\";
+export { DirectorScalarRelationFilter } from \\"./DirectorScalarRelationFilter\\";
 export { DirectorScalarWhereWithAggregatesInput } from \\"./DirectorScalarWhereWithAggregatesInput\\";
 export { DirectorSumOrderByAggregateInput } from \\"./DirectorSumOrderByAggregateInput\\";
 export { DirectorUpdateInput } from \\"./DirectorUpdateInput\\";
@@ -3521,7 +3535,7 @@ exports[`inputs should properly generate input type classes for model with id ke
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"MovieDirectorFirstNameDirectorLastNameTitleCompoundUniqueInput\\", {})
 export class MovieDirectorFirstNameDirectorLastNameTitleCompoundUniqueInput {
@@ -3547,7 +3561,7 @@ exports[`inputs should properly generate input type classes for model with id ke
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { DirectorOrderByWithRelationInput } from \\"../inputs/DirectorOrderByWithRelationInput\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
@@ -3585,7 +3599,7 @@ exports[`inputs should properly generate input type classes for model with id ke
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { StringFilter } from \\"../inputs/StringFilter\\";
 
@@ -3633,8 +3647,8 @@ exports[`inputs should properly generate input type classes for model with id ke
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
-import { DirectorRelationFilter } from \\"../inputs/DirectorRelationFilter\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
+import { DirectorScalarRelationFilter } from \\"../inputs/DirectorScalarRelationFilter\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { StringFilter } from \\"../inputs/StringFilter\\";
 
@@ -3675,10 +3689,10 @@ export class MovieWhereInput {
   })
   rating?: FloatFilter | undefined;
 
-  @TypeGraphQL.Field(_type => DirectorRelationFilter, {
+  @TypeGraphQL.Field(_type => DirectorScalarRelationFilter, {
     nullable: true
   })
-  director?: DirectorRelationFilter | undefined;
+  director?: DirectorScalarRelationFilter | undefined;
 }
 "
 `;
@@ -3687,8 +3701,8 @@ exports[`inputs should properly generate input type classes for model with id ke
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
-import { DirectorRelationFilter } from \\"../inputs/DirectorRelationFilter\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
+import { DirectorScalarRelationFilter } from \\"../inputs/DirectorScalarRelationFilter\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { MovieDirectorFirstNameDirectorLastNameTitleCompoundUniqueInput } from \\"../inputs/MovieDirectorFirstNameDirectorLastNameTitleCompoundUniqueInput\\";
 import { MovieWhereInput } from \\"../inputs/MovieWhereInput\\";
@@ -3736,10 +3750,10 @@ export class MovieWhereUniqueInput {
   })
   rating?: FloatFilter | undefined;
 
-  @TypeGraphQL.Field(_type => DirectorRelationFilter, {
+  @TypeGraphQL.Field(_type => DirectorScalarRelationFilter, {
     nullable: true
   })
-  director?: DirectorRelationFilter | undefined;
+  director?: DirectorScalarRelationFilter | undefined;
 }
 "
 `;
@@ -3757,7 +3771,7 @@ export { DirectorMaxOrderByAggregateInput } from \\"./DirectorMaxOrderByAggregat
 export { DirectorMinOrderByAggregateInput } from \\"./DirectorMinOrderByAggregateInput\\";
 export { DirectorOrderByWithAggregationInput } from \\"./DirectorOrderByWithAggregationInput\\";
 export { DirectorOrderByWithRelationInput } from \\"./DirectorOrderByWithRelationInput\\";
-export { DirectorRelationFilter } from \\"./DirectorRelationFilter\\";
+export { DirectorScalarRelationFilter } from \\"./DirectorScalarRelationFilter\\";
 export { DirectorScalarWhereWithAggregatesInput } from \\"./DirectorScalarWhereWithAggregatesInput\\";
 export { DirectorSumOrderByAggregateInput } from \\"./DirectorSumOrderByAggregateInput\\";
 export { DirectorUpdateInput } from \\"./DirectorUpdateInput\\";
@@ -3818,7 +3832,7 @@ exports[`inputs should properly generate input type classes for model with nativ
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { BytesScalar, DecimalJSScalar } from "../../scalars";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"NativeTypeModelCreateInput\\", {})
 export class NativeTypeModelCreateInput {
@@ -3844,7 +3858,7 @@ exports[`inputs should properly generate input type classes for model with nativ
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SortOrderInput } from \\"../inputs/SortOrderInput\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
@@ -3877,7 +3891,7 @@ exports[`inputs should properly generate input type classes for model with nativ
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NullableBigIntFieldUpdateOperationsInput } from \\"../inputs/NullableBigIntFieldUpdateOperationsInput\\";
 import { NullableBytesFieldUpdateOperationsInput } from \\"../inputs/NullableBytesFieldUpdateOperationsInput\\";
 import { NullableDecimalFieldUpdateOperationsInput } from \\"../inputs/NullableDecimalFieldUpdateOperationsInput\\";
@@ -3906,7 +3920,7 @@ exports[`inputs should properly generate input type classes for model with nativ
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NullableBigIntFieldUpdateOperationsInput } from \\"../inputs/NullableBigIntFieldUpdateOperationsInput\\";
 import { NullableBytesFieldUpdateOperationsInput } from \\"../inputs/NullableBytesFieldUpdateOperationsInput\\";
 import { NullableDecimalFieldUpdateOperationsInput } from \\"../inputs/NullableDecimalFieldUpdateOperationsInput\\";
@@ -3935,7 +3949,7 @@ exports[`inputs should properly generate input type classes for model with nativ
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { BigIntNullableFilter } from \\"../inputs/BigIntNullableFilter\\";
 import { BytesNullableFilter } from \\"../inputs/BytesNullableFilter\\";
 import { DecimalNullableFilter } from \\"../inputs/DecimalNullableFilter\\";
@@ -3985,7 +3999,7 @@ exports[`inputs should properly generate input type classes for model with nativ
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { BigIntNullableFilter } from \\"../inputs/BigIntNullableFilter\\";
 import { BytesNullableFilter } from \\"../inputs/BytesNullableFilter\\";
 import { DecimalNullableFilter } from \\"../inputs/DecimalNullableFilter\\";
@@ -4077,7 +4091,7 @@ exports[`inputs should properly generate input type classes for sorting by many-
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SecondModelOrderByRelationAggregateInput } from \\"../inputs/SecondModelOrderByRelationAggregateInput\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
@@ -4110,7 +4124,7 @@ exports[`inputs should properly generate input type classes for sorting by many-
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
 @TypeGraphQL.InputType(\\"SampleAvgOrderByAggregateInput\\", {})
@@ -4137,7 +4151,7 @@ exports[`inputs should properly generate input type classes for sorting by many-
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
 @TypeGraphQL.InputType(\\"SampleCountOrderByAggregateInput\\", {})
@@ -4184,7 +4198,7 @@ exports[`inputs should properly generate input type classes for sorting by many-
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
 @TypeGraphQL.InputType(\\"SampleMaxOrderByAggregateInput\\", {})
@@ -4226,7 +4240,7 @@ exports[`inputs should properly generate input type classes for sorting by many-
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
 @TypeGraphQL.InputType(\\"SampleMinOrderByAggregateInput\\", {})
@@ -4268,7 +4282,7 @@ exports[`inputs should properly generate input type classes for sorting by many-
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SampleAvgOrderByAggregateInput } from \\"../inputs/SampleAvgOrderByAggregateInput\\";
 import { SampleCountOrderByAggregateInput } from \\"../inputs/SampleCountOrderByAggregateInput\\";
 import { SampleMaxOrderByAggregateInput } from \\"../inputs/SampleMaxOrderByAggregateInput\\";
@@ -4345,7 +4359,7 @@ exports[`inputs should properly generate input type classes for sorting by many-
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
 @TypeGraphQL.InputType(\\"SecondModelOrderByRelationAggregateInput\\", {})
@@ -4477,7 +4491,7 @@ exports[`inputs should properly generate input type classes for sorting by one-t
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SecondModelOrderByRelationAggregateInput } from \\"../inputs/SecondModelOrderByRelationAggregateInput\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
@@ -4510,7 +4524,7 @@ exports[`inputs should properly generate input type classes for sorting by one-t
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
 @TypeGraphQL.InputType(\\"SecondModelOrderByRelationAggregateInput\\", {})
@@ -4527,7 +4541,7 @@ exports[`inputs should properly generate input type classes for sorting by one-t
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelOrderByWithRelationInput } from \\"../inputs/FirstModelOrderByWithRelationInput\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
@@ -4573,7 +4587,7 @@ export { FirstModelMaxOrderByAggregateInput } from \\"./FirstModelMaxOrderByAggr
 export { FirstModelMinOrderByAggregateInput } from \\"./FirstModelMinOrderByAggregateInput\\";
 export { FirstModelOrderByWithAggregationInput } from \\"./FirstModelOrderByWithAggregationInput\\";
 export { FirstModelOrderByWithRelationInput } from \\"./FirstModelOrderByWithRelationInput\\";
-export { FirstModelRelationFilter } from \\"./FirstModelRelationFilter\\";
+export { FirstModelScalarRelationFilter } from \\"./FirstModelScalarRelationFilter\\";
 export { FirstModelScalarWhereWithAggregatesInput } from \\"./FirstModelScalarWhereWithAggregatesInput\\";
 export { FirstModelSumOrderByAggregateInput } from \\"./FirstModelSumOrderByAggregateInput\\";
 export { FirstModelUpdateInput } from \\"./FirstModelUpdateInput\\";
@@ -4633,7 +4647,7 @@ exports[`inputs should properly generate input type classes for updating scalar 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SampleNestedTypeCreateInput } from \\"../inputs/SampleNestedTypeCreateInput\\";
 import { Color } from \\"../../enums/Color\\";
 
@@ -4736,7 +4750,7 @@ exports[`inputs should properly generate input type classes for updating scalar 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SampleNestedTypeCreateInput } from \\"../inputs/SampleNestedTypeCreateInput\\";
 import { Color } from \\"../../enums/Color\\";
 
@@ -4839,7 +4853,7 @@ exports[`inputs should properly generate input type classes for updating scalar 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SampleNestedTypeCreateInput } from \\"../inputs/SampleNestedTypeCreateInput\\";
 import { Color } from \\"../../enums/Color\\";
 
@@ -4937,7 +4951,7 @@ exports[`inputs should properly generate input type classes for updating scalar 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SampleNestedTypeCreateInput } from \\"../inputs/SampleNestedTypeCreateInput\\";
 import { Color } from \\"../../enums/Color\\";
 
@@ -5035,7 +5049,7 @@ exports[`inputs should properly generate input type classes for updating scalar 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"SampleNestedTypeCreateInput\\", {})
 export class SampleNestedTypeCreateInput {
@@ -5066,7 +5080,7 @@ exports[`inputs should properly generate input type classes for updating scalar 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"SampleNestedTypeUpdateInput\\", {})
 export class SampleNestedTypeUpdateInput {
@@ -5199,7 +5213,7 @@ exports[`inputs should properly generate input type classes for updating scalar 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"BoolFieldUpdateOperationsInput\\", {})
 export class BoolFieldUpdateOperationsInput {
@@ -5215,7 +5229,7 @@ exports[`inputs should properly generate input type classes for updating scalar 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"DateTimeFieldUpdateOperationsInput\\", {})
 export class DateTimeFieldUpdateOperationsInput {
@@ -5231,7 +5245,7 @@ exports[`inputs should properly generate input type classes for updating scalar 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { Color } from \\"../../enums/Color\\";
 
 @TypeGraphQL.InputType(\\"EnumColorFieldUpdateOperationsInput\\", {})
@@ -5248,7 +5262,7 @@ exports[`inputs should properly generate input type classes for updating scalar 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"FloatFieldUpdateOperationsInput\\", {})
 export class FloatFieldUpdateOperationsInput {
@@ -5284,7 +5298,7 @@ exports[`inputs should properly generate input type classes for updating scalar 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"IntFieldUpdateOperationsInput\\", {})
 export class IntFieldUpdateOperationsInput {
@@ -5320,7 +5334,7 @@ exports[`inputs should properly generate input type classes for updating scalar 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { BoolFieldUpdateOperationsInput } from \\"../inputs/BoolFieldUpdateOperationsInput\\";
 import { DateTimeFieldUpdateOperationsInput } from \\"../inputs/DateTimeFieldUpdateOperationsInput\\";
 import { EnumColorFieldUpdateOperationsInput } from \\"../inputs/EnumColorFieldUpdateOperationsInput\\";
@@ -5425,7 +5439,7 @@ exports[`inputs should properly generate input type classes for updating scalar 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { BoolFieldUpdateOperationsInput } from \\"../inputs/BoolFieldUpdateOperationsInput\\";
 import { DateTimeFieldUpdateOperationsInput } from \\"../inputs/DateTimeFieldUpdateOperationsInput\\";
 import { EnumColorFieldUpdateOperationsInput } from \\"../inputs/EnumColorFieldUpdateOperationsInput\\";
@@ -5530,7 +5544,7 @@ exports[`inputs should properly generate input type classes for updating scalar 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"SampleModelUpdateintArrayFieldInput\\", {})
 export class SampleModelUpdateintArrayFieldInput {
@@ -5551,7 +5565,7 @@ exports[`inputs should properly generate input type classes for updating scalar 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"SampleModelUpdatestringArrayFieldInput\\", {})
 export class SampleModelUpdatestringArrayFieldInput {
@@ -5572,7 +5586,7 @@ exports[`inputs should properly generate input type classes for updating scalar 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"StringFieldUpdateOperationsInput\\", {})
 export class StringFieldUpdateOperationsInput {
@@ -5679,7 +5693,7 @@ exports[`inputs should properly generate input type classes with SortOrderInput 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelAvgOrderByAggregateInput } from \\"../inputs/FirstModelAvgOrderByAggregateInput\\";
 import { FirstModelCountOrderByAggregateInput } from \\"../inputs/FirstModelCountOrderByAggregateInput\\";
 import { FirstModelMaxOrderByAggregateInput } from \\"../inputs/FirstModelMaxOrderByAggregateInput\\";
@@ -5737,7 +5751,7 @@ exports[`inputs should properly generate input type classes with SortOrderInput 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelCreateOrConnectWithoutSecondModelsFieldInput } from \\"../inputs/FirstModelCreateOrConnectWithoutSecondModelsFieldInput\\";
 import { FirstModelCreateWithoutSecondModelsFieldInput } from \\"../inputs/FirstModelCreateWithoutSecondModelsFieldInput\\";
 import { FirstModelUpdateToOneWithWhereWithoutSecondModelsFieldInput } from \\"../inputs/FirstModelUpdateToOneWithWhereWithoutSecondModelsFieldInput\\";
@@ -5778,7 +5792,7 @@ exports[`inputs should properly generate input type classes with SortOrderInput 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelUpdateWithoutSecondModelsFieldInput } from \\"../inputs/FirstModelUpdateWithoutSecondModelsFieldInput\\";
 import { FirstModelWhereInput } from \\"../inputs/FirstModelWhereInput\\";
 
@@ -5801,7 +5815,7 @@ exports[`inputs should properly generate input type classes with SortOrderInput 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelWhereInput } from \\"../inputs/FirstModelWhereInput\\";
 import { FloatNullableFilter } from \\"../inputs/FloatNullableFilter\\";
 import { SecondModelListRelationFilter } from \\"../inputs/SecondModelListRelationFilter\\";
@@ -5850,7 +5864,7 @@ exports[`inputs should properly generate input type classes with SortOrderInput 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SecondModelCreateWithoutFirstModelFieldInput } from \\"../inputs/SecondModelCreateWithoutFirstModelFieldInput\\";
 import { SecondModelUpdateWithoutFirstModelFieldInput } from \\"../inputs/SecondModelUpdateWithoutFirstModelFieldInput\\";
 import { SecondModelWhereUniqueInput } from \\"../inputs/SecondModelWhereUniqueInput\\";
@@ -5879,7 +5893,7 @@ exports[`inputs should properly generate input type classes with SortOrderInput 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NullsOrder } from \\"../../enums/NullsOrder\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
@@ -5910,7 +5924,7 @@ export { FirstModelMaxOrderByAggregateInput } from \\"./FirstModelMaxOrderByAggr
 export { FirstModelMinOrderByAggregateInput } from \\"./FirstModelMinOrderByAggregateInput\\";
 export { FirstModelOrderByWithAggregationInput } from \\"./FirstModelOrderByWithAggregationInput\\";
 export { FirstModelOrderByWithRelationInput } from \\"./FirstModelOrderByWithRelationInput\\";
-export { FirstModelRelationFilter } from \\"./FirstModelRelationFilter\\";
+export { FirstModelScalarRelationFilter } from \\"./FirstModelScalarRelationFilter\\";
 export { FirstModelScalarWhereWithAggregatesInput } from \\"./FirstModelScalarWhereWithAggregatesInput\\";
 export { FirstModelSumOrderByAggregateInput } from \\"./FirstModelSumOrderByAggregateInput\\";
 export { FirstModelUpdateInput } from \\"./FirstModelUpdateInput\\";
@@ -5981,7 +5995,7 @@ export { FirstModelMaxOrderByAggregateInput } from \\"./FirstModelMaxOrderByAggr
 export { FirstModelMinOrderByAggregateInput } from \\"./FirstModelMinOrderByAggregateInput\\";
 export { FirstModelOrderByWithAggregationInput } from \\"./FirstModelOrderByWithAggregationInput\\";
 export { FirstModelOrderByWithRelationInput } from \\"./FirstModelOrderByWithRelationInput\\";
-export { FirstModelRelationFilter } from \\"./FirstModelRelationFilter\\";
+export { FirstModelScalarRelationFilter } from \\"./FirstModelScalarRelationFilter\\";
 export { FirstModelScalarWhereWithAggregatesInput } from \\"./FirstModelScalarWhereWithAggregatesInput\\";
 export { FirstModelSumOrderByAggregateInput } from \\"./FirstModelSumOrderByAggregateInput\\";
 export { FirstModelUpdateInput } from \\"./FirstModelUpdateInput\\";
@@ -6044,7 +6058,7 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedBigIntNullableFilter } from \\"../inputs/NestedBigIntNullableFilter\\";
 
 @TypeGraphQL.InputType(\\"BigIntNullableFilter\\", {})
@@ -6096,7 +6110,7 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedBigIntNullableFilter } from \\"../inputs/NestedBigIntNullableFilter\\";
 import { NestedBigIntNullableWithAggregatesFilter } from \\"../inputs/NestedBigIntNullableWithAggregatesFilter\\";
 import { NestedFloatNullableFilter } from \\"../inputs/NestedFloatNullableFilter\\";
@@ -6176,7 +6190,7 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { BytesScalar, DecimalJSScalar } from "../../scalars";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedBytesNullableFilter } from \\"../inputs/NestedBytesNullableFilter\\";
 
 @TypeGraphQL.InputType(\\"BytesNullableFilter\\", {})
@@ -6208,7 +6222,7 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { BytesScalar, DecimalJSScalar } from "../../scalars";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedBytesNullableFilter } from \\"../inputs/NestedBytesNullableFilter\\";
 import { NestedBytesNullableWithAggregatesFilter } from \\"../inputs/NestedBytesNullableWithAggregatesFilter\\";
 import { NestedIntNullableFilter } from \\"../inputs/NestedIntNullableFilter\\";
@@ -6257,7 +6271,7 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedDecimalNullableFilter } from \\"../inputs/NestedDecimalNullableFilter\\";
 
 @TypeGraphQL.InputType(\\"DecimalNullableFilter\\", {})
@@ -6309,7 +6323,7 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedDecimalNullableFilter } from \\"../inputs/NestedDecimalNullableFilter\\";
 import { NestedDecimalNullableWithAggregatesFilter } from \\"../inputs/NestedDecimalNullableWithAggregatesFilter\\";
 import { NestedIntNullableFilter } from \\"../inputs/NestedIntNullableFilter\\";
@@ -6388,7 +6402,7 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { BytesScalar, DecimalJSScalar } from "../../scalars";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"NestedBytesNullableFilter\\", {})
 export class NestedBytesNullableFilter {
@@ -6419,7 +6433,7 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { BytesScalar, DecimalJSScalar } from "../../scalars";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedBytesNullableFilter } from \\"../inputs/NestedBytesNullableFilter\\";
 import { NestedIntNullableFilter } from \\"../inputs/NestedIntNullableFilter\\";
 
@@ -6467,7 +6481,7 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"NestedDecimalNullableFilter\\", {})
 export class NestedDecimalNullableFilter {
@@ -6518,7 +6532,7 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedDecimalNullableFilter } from \\"../inputs/NestedDecimalNullableFilter\\";
 import { NestedIntNullableFilter } from \\"../inputs/NestedIntNullableFilter\\";
 
@@ -6596,7 +6610,7 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"NullableBigIntFieldUpdateOperationsInput\\", {})
 export class NullableBigIntFieldUpdateOperationsInput {
@@ -6632,7 +6646,7 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { BytesScalar, DecimalJSScalar } from "../../scalars";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"NullableBytesFieldUpdateOperationsInput\\", {})
 export class NullableBytesFieldUpdateOperationsInput {
@@ -6648,7 +6662,7 @@ exports[`inputs should properly generate input type scalar filters classes for m
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"NullableDecimalFieldUpdateOperationsInput\\", {})
 export class NullableDecimalFieldUpdateOperationsInput {
@@ -6726,7 +6740,7 @@ exports[`inputs when \`emitIsAbstract\` generator option is enabled should prope
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelWhereInput } from \\"../inputs/FirstModelWhereInput\\";
 import { FloatNullableFilter } from \\"../inputs/FloatNullableFilter\\";
 
@@ -6771,7 +6785,7 @@ exports[`inputs when \`fullTextSearchPostgres\` preview feature is enabled shoul
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelOrderByRelevanceFieldEnum } from \\"../../enums/FirstModelOrderByRelevanceFieldEnum\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
@@ -6799,7 +6813,7 @@ exports[`inputs when \`fullTextSearchPostgres\` preview feature is enabled shoul
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelOrderByRelevanceInput } from \\"../inputs/FirstModelOrderByRelevanceInput\\";
 import { SecondModelOrderByRelationAggregateInput } from \\"../inputs/SecondModelOrderByRelationAggregateInput\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
@@ -6838,7 +6852,7 @@ exports[`inputs when \`fullTextSearchPostgres\` preview feature is enabled shoul
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"NestedStringFilter\\", {})
 export class NestedStringFilter {
@@ -6909,7 +6923,7 @@ exports[`inputs when \`fullTextSearchPostgres\` preview feature is enabled shoul
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { NestedStringFilter } from \\"../inputs/NestedStringFilter\\";
 import { QueryMode } from \\"../../enums/QueryMode\\";
 
@@ -6996,7 +7010,7 @@ export { FirstModelMinOrderByAggregateInput } from \\"./FirstModelMinOrderByAggr
 export { FirstModelOrderByRelevanceInput } from \\"./FirstModelOrderByRelevanceInput\\";
 export { FirstModelOrderByWithAggregationInput } from \\"./FirstModelOrderByWithAggregationInput\\";
 export { FirstModelOrderByWithRelationInput } from \\"./FirstModelOrderByWithRelationInput\\";
-export { FirstModelRelationFilter } from \\"./FirstModelRelationFilter\\";
+export { FirstModelScalarRelationFilter } from \\"./FirstModelScalarRelationFilter\\";
 export { FirstModelScalarWhereWithAggregatesInput } from \\"./FirstModelScalarWhereWithAggregatesInput\\";
 export { FirstModelSumOrderByAggregateInput } from \\"./FirstModelSumOrderByAggregateInput\\";
 export { FirstModelUpdateInput } from \\"./FirstModelUpdateInput\\";
@@ -7057,7 +7071,7 @@ exports[`inputs when model field is renamed should properly generate input type 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
 @TypeGraphQL.InputType(\\"SampleOrderByWithRelationInput\\", {})
@@ -7087,7 +7101,7 @@ exports[`inputs when model field is renamed should properly generate input type 
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
 import { StringFilter } from \\"../inputs/StringFilter\\";
 
@@ -7162,7 +7176,7 @@ exports[`inputs when model is renamed should properly generate input type classe
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { RenamedSecondModelOrderByRelationAggregateInput } from \\"../inputs/RenamedSecondModelOrderByRelationAggregateInput\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
@@ -7195,7 +7209,7 @@ exports[`inputs when model is renamed should properly generate input type classe
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
 import { StringFilter } from \\"../inputs/StringFilter\\";
@@ -7239,7 +7253,7 @@ exports[`inputs when model is renamed should properly generate input type classe
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
 import { RenamedSecondModelListRelationFilter } from \\"../inputs/RenamedSecondModelListRelationFilter\\";
@@ -7289,7 +7303,7 @@ exports[`inputs when model is renamed should properly generate input type classe
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { RenamedFirstModelWhereInput } from \\"../inputs/RenamedFirstModelWhereInput\\";
 import { RenamedSecondModelListRelationFilter } from \\"../inputs/RenamedSecondModelListRelationFilter\\";
@@ -7407,7 +7421,7 @@ exports[`inputs when model is renamed should properly generate input type classe
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { RenamedSecondModelOrderByRelationAggregateInput } from \\"../inputs/RenamedSecondModelOrderByRelationAggregateInput\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
@@ -7436,33 +7450,11 @@ export class RenamedFirstModelOrderByWithRelationInput {
 "
 `;
 
-exports[`inputs when model is renamed should properly generate input type classes for filtering models by one to many relation fields: RenamedFirstModelRelationFilter 1`] = `
-"import * as TypeGraphQL from \\"type-graphql\\";
-import * as GraphQLScalars from \\"graphql-scalars\\";
-import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
-import { RenamedFirstModelWhereInput } from \\"../inputs/RenamedFirstModelWhereInput\\";
-
-@TypeGraphQL.InputType(\\"RenamedFirstModelRelationFilter\\", {})
-export class RenamedFirstModelRelationFilter {
-  @TypeGraphQL.Field(_type => RenamedFirstModelWhereInput, {
-    nullable: true
-  })
-  is?: RenamedFirstModelWhereInput | undefined;
-
-  @TypeGraphQL.Field(_type => RenamedFirstModelWhereInput, {
-    nullable: true
-  })
-  isNot?: RenamedFirstModelWhereInput | undefined;
-}
-"
-`;
-
 exports[`inputs when model is renamed should properly generate input type classes for filtering models by one to many relation fields: RenamedFirstModelWhereInput 1`] = `
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
 import { RenamedSecondModelListRelationFilter } from \\"../inputs/RenamedSecondModelListRelationFilter\\";
@@ -7512,7 +7504,7 @@ exports[`inputs when model is renamed should properly generate input type classe
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { RenamedFirstModelWhereInput } from \\"../inputs/RenamedFirstModelWhereInput\\";
 import { RenamedSecondModelListRelationFilter } from \\"../inputs/RenamedSecondModelListRelationFilter\\";
@@ -7561,7 +7553,7 @@ exports[`inputs when model is renamed should properly generate input type classe
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { RenamedSecondModelWhereInput } from \\"../inputs/RenamedSecondModelWhereInput\\";
 
 @TypeGraphQL.InputType(\\"RenamedSecondModelListRelationFilter\\", {})
@@ -7588,7 +7580,7 @@ exports[`inputs when model is renamed should properly generate input type classe
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { RenamedFirstModelOrderByWithRelationInput } from \\"../inputs/RenamedFirstModelOrderByWithRelationInput\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
@@ -7626,7 +7618,7 @@ exports[`inputs when model is renamed should properly generate input type classe
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
 import { StringFilter } from \\"../inputs/StringFilter\\";
@@ -7675,10 +7667,10 @@ exports[`inputs when model is renamed should properly generate input type classe
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
-import { RenamedFirstModelRelationFilter } from \\"../inputs/RenamedFirstModelRelationFilter\\";
+import { RenamedFirstModelScalarRelationFilter } from \\"../inputs/RenamedFirstModelScalarRelationFilter\\";
 import { StringFilter } from \\"../inputs/StringFilter\\";
 
 @TypeGraphQL.InputType(\\"RenamedSecondModelWhereInput\\", {})
@@ -7718,10 +7710,10 @@ export class RenamedSecondModelWhereInput {
   })
   firstModelFieldId?: IntFilter | undefined;
 
-  @TypeGraphQL.Field(_type => RenamedFirstModelRelationFilter, {
+  @TypeGraphQL.Field(_type => RenamedFirstModelScalarRelationFilter, {
     nullable: true
   })
-  firstModelField?: RenamedFirstModelRelationFilter | undefined;
+  firstModelField?: RenamedFirstModelScalarRelationFilter | undefined;
 }
 "
 `;
@@ -7730,10 +7722,10 @@ exports[`inputs when model is renamed should properly generate input type classe
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
-import { RenamedFirstModelRelationFilter } from \\"../inputs/RenamedFirstModelRelationFilter\\";
+import { RenamedFirstModelScalarRelationFilter } from \\"../inputs/RenamedFirstModelScalarRelationFilter\\";
 import { RenamedSecondModelWhereInput } from \\"../inputs/RenamedSecondModelWhereInput\\";
 
 @TypeGraphQL.InputType(\\"RenamedSecondModelWhereUniqueInput\\", {})
@@ -7773,10 +7765,10 @@ export class RenamedSecondModelWhereUniqueInput {
   })
   firstModelFieldId?: IntFilter | undefined;
 
-  @TypeGraphQL.Field(_type => RenamedFirstModelRelationFilter, {
+  @TypeGraphQL.Field(_type => RenamedFirstModelScalarRelationFilter, {
     nullable: true
   })
-  firstModelField?: RenamedFirstModelRelationFilter | undefined;
+  firstModelField?: RenamedFirstModelScalarRelationFilter | undefined;
 }
 "
 `;
@@ -7805,7 +7797,7 @@ export { RenamedFirstModelMaxOrderByAggregateInput } from \\"./RenamedFirstModel
 export { RenamedFirstModelMinOrderByAggregateInput } from \\"./RenamedFirstModelMinOrderByAggregateInput\\";
 export { RenamedFirstModelOrderByWithAggregationInput } from \\"./RenamedFirstModelOrderByWithAggregationInput\\";
 export { RenamedFirstModelOrderByWithRelationInput } from \\"./RenamedFirstModelOrderByWithRelationInput\\";
-export { RenamedFirstModelRelationFilter } from \\"./RenamedFirstModelRelationFilter\\";
+export { RenamedFirstModelScalarRelationFilter } from \\"./RenamedFirstModelScalarRelationFilter\\";
 export { RenamedFirstModelScalarWhereWithAggregatesInput } from \\"./RenamedFirstModelScalarWhereWithAggregatesInput\\";
 export { RenamedFirstModelSumOrderByAggregateInput } from \\"./RenamedFirstModelSumOrderByAggregateInput\\";
 export { RenamedFirstModelUpdateInput } from \\"./RenamedFirstModelUpdateInput\\";
@@ -7853,7 +7845,7 @@ exports[`inputs when model is renamed should properly generate input type classe
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { OtherModelOrderByWithRelationInput } from \\"../inputs/OtherModelOrderByWithRelationInput\\";
 import { SortOrder } from \\"../../enums/SortOrder\\";
 
@@ -7901,12 +7893,12 @@ exports[`inputs when model is renamed should properly generate input type classe
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { BoolFilter } from \\"../inputs/BoolFilter\\";
 import { DateTimeFilter } from \\"../inputs/DateTimeFilter\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
-import { OtherModelRelationFilter } from \\"../inputs/OtherModelRelationFilter\\";
+import { OtherModelScalarRelationFilter } from \\"../inputs/OtherModelScalarRelationFilter\\";
 import { StringFilter } from \\"../inputs/StringFilter\\";
 
 @TypeGraphQL.InputType(\\"ExampleWhereInput\\", {})
@@ -7956,10 +7948,10 @@ export class ExampleWhereInput {
   })
   otherId?: IntFilter | undefined;
 
-  @TypeGraphQL.Field(_type => OtherModelRelationFilter, {
+  @TypeGraphQL.Field(_type => OtherModelScalarRelationFilter, {
     nullable: true
   })
-  other?: OtherModelRelationFilter | undefined;
+  other?: OtherModelScalarRelationFilter | undefined;
 }
 "
 `;
@@ -7968,13 +7960,13 @@ exports[`inputs when model is renamed should properly generate input type classe
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { BoolFilter } from \\"../inputs/BoolFilter\\";
 import { DateTimeFilter } from \\"../inputs/DateTimeFilter\\";
 import { ExampleWhereInput } from \\"../inputs/ExampleWhereInput\\";
 import { FloatFilter } from \\"../inputs/FloatFilter\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
-import { OtherModelRelationFilter } from \\"../inputs/OtherModelRelationFilter\\";
+import { OtherModelScalarRelationFilter } from \\"../inputs/OtherModelScalarRelationFilter\\";
 
 @TypeGraphQL.InputType(\\"ExampleWhereUniqueInput\\", {})
 export class ExampleWhereUniqueInput {
@@ -8023,10 +8015,10 @@ export class ExampleWhereUniqueInput {
   })
   otherId?: IntFilter | undefined;
 
-  @TypeGraphQL.Field(_type => OtherModelRelationFilter, {
+  @TypeGraphQL.Field(_type => OtherModelScalarRelationFilter, {
     nullable: true
   })
-  other?: OtherModelRelationFilter | undefined;
+  other?: OtherModelScalarRelationFilter | undefined;
 }
 "
 `;
@@ -8092,7 +8084,7 @@ export { OtherModelMaxOrderByAggregateInput } from \\"./OtherModelMaxOrderByAggr
 export { OtherModelMinOrderByAggregateInput } from \\"./OtherModelMinOrderByAggregateInput\\";
 export { OtherModelOrderByWithAggregationInput } from \\"./OtherModelOrderByWithAggregationInput\\";
 export { OtherModelOrderByWithRelationInput } from \\"./OtherModelOrderByWithRelationInput\\";
-export { OtherModelRelationFilter } from \\"./OtherModelRelationFilter\\";
+export { OtherModelScalarRelationFilter } from \\"./OtherModelScalarRelationFilter\\";
 export { OtherModelScalarWhereWithAggregatesInput } from \\"./OtherModelScalarWhereWithAggregatesInput\\";
 export { OtherModelSumOrderByAggregateInput } from \\"./OtherModelSumOrderByAggregateInput\\";
 export { OtherModelUpdateInput } from \\"./OtherModelUpdateInput\\";
@@ -8113,7 +8105,7 @@ exports[`inputs when prisma client is generated into node_modules should properl
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"@prisma/client\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { IntFilter } from \\"../inputs/IntFilter\\";
 import { StringFilter } from \\"../inputs/StringFilter\\";
 
@@ -8180,7 +8172,7 @@ exports[`inputs when useSimpleInputs config option is set to true should properl
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { Color } from \\"../../enums/Color\\";
 
 @TypeGraphQL.InputType(\\"SampleModelUpdateInput\\", {})
@@ -8272,7 +8264,7 @@ exports[`inputs when useSimpleInputs config option is set to true should properl
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { Color } from \\"../../enums/Color\\";
 
 @TypeGraphQL.InputType(\\"SampleModelUpdateManyMutationInput\\", {})
@@ -8455,7 +8447,7 @@ exports[`inputs when useUncheckedScalarInputs mode is enabled should properly ge
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelCreateOrConnectWithoutSecondModelsFieldInput } from \\"../inputs/FirstModelCreateOrConnectWithoutSecondModelsFieldInput\\";
 import { FirstModelUncheckedCreateWithoutSecondModelsFieldInput } from \\"../inputs/FirstModelUncheckedCreateWithoutSecondModelsFieldInput\\";
 import { FirstModelWhereUniqueInput } from \\"../inputs/FirstModelWhereUniqueInput\\";
@@ -8484,7 +8476,7 @@ exports[`inputs when useUncheckedScalarInputs mode is enabled should properly ge
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelUncheckedCreateWithoutSecondModelsFieldInput } from \\"../inputs/FirstModelUncheckedCreateWithoutSecondModelsFieldInput\\";
 import { FirstModelWhereUniqueInput } from \\"../inputs/FirstModelWhereUniqueInput\\";
 
@@ -8507,7 +8499,7 @@ exports[`inputs when useUncheckedScalarInputs mode is enabled should properly ge
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"FirstModelCreateWithoutSecondModelsFieldInput\\", {})
 export class FirstModelCreateWithoutSecondModelsFieldInput {
@@ -8528,7 +8520,7 @@ exports[`inputs when useUncheckedScalarInputs mode is enabled should properly ge
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { SecondModelUncheckedCreateNestedManyWithoutFirstModelFieldInput } from \\"../inputs/SecondModelUncheckedCreateNestedManyWithoutFirstModelFieldInput\\";
 
 @TypeGraphQL.InputType(\\"FirstModelUncheckedCreateInput\\", {})
@@ -8560,7 +8552,7 @@ exports[`inputs when useUncheckedScalarInputs mode is enabled should properly ge
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 
 @TypeGraphQL.InputType(\\"FirstModelUncheckedCreateWithoutSecondModelsFieldInput\\", {})
 export class FirstModelUncheckedCreateWithoutSecondModelsFieldInput {
@@ -8586,7 +8578,7 @@ exports[`inputs when useUncheckedScalarInputs mode is enabled should properly ge
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFieldUpdateOperationsInput } from \\"../inputs/FloatFieldUpdateOperationsInput\\";
 import { IntFieldUpdateOperationsInput } from \\"../inputs/IntFieldUpdateOperationsInput\\";
 import { SecondModelUncheckedUpdateManyWithoutFirstModelFieldNestedInput } from \\"../inputs/SecondModelUncheckedUpdateManyWithoutFirstModelFieldNestedInput\\";
@@ -8621,7 +8613,7 @@ exports[`inputs when useUncheckedScalarInputs mode is enabled should properly ge
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFieldUpdateOperationsInput } from \\"../inputs/FloatFieldUpdateOperationsInput\\";
 import { IntFieldUpdateOperationsInput } from \\"../inputs/IntFieldUpdateOperationsInput\\";
 import { StringFieldUpdateOperationsInput } from \\"../inputs/StringFieldUpdateOperationsInput\\";
@@ -8650,7 +8642,7 @@ exports[`inputs when useUncheckedScalarInputs mode is enabled should properly ge
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFieldUpdateOperationsInput } from \\"../inputs/FloatFieldUpdateOperationsInput\\";
 import { IntFieldUpdateOperationsInput } from \\"../inputs/IntFieldUpdateOperationsInput\\";
 import { StringFieldUpdateOperationsInput } from \\"../inputs/StringFieldUpdateOperationsInput\\";
@@ -8679,7 +8671,7 @@ exports[`inputs when useUncheckedScalarInputs mode is enabled should properly ge
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelCreateOrConnectWithoutSecondModelsFieldInput } from \\"../inputs/FirstModelCreateOrConnectWithoutSecondModelsFieldInput\\";
 import { FirstModelUncheckedCreateWithoutSecondModelsFieldInput } from \\"../inputs/FirstModelUncheckedCreateWithoutSecondModelsFieldInput\\";
 import { FirstModelUncheckedUpdateWithoutSecondModelsFieldInput } from \\"../inputs/FirstModelUncheckedUpdateWithoutSecondModelsFieldInput\\";
@@ -8720,7 +8712,7 @@ exports[`inputs when useUncheckedScalarInputs mode is enabled should properly ge
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FloatFieldUpdateOperationsInput } from \\"../inputs/FloatFieldUpdateOperationsInput\\";
 import { StringFieldUpdateOperationsInput } from \\"../inputs/StringFieldUpdateOperationsInput\\";
 
@@ -8743,7 +8735,7 @@ exports[`inputs when useUncheckedScalarInputs mode is enabled should properly ge
 "import * as TypeGraphQL from \\"type-graphql\\";
 import * as GraphQLScalars from \\"graphql-scalars\\";
 import { Prisma } from \\"../../../../helpers/prisma-client-mock\\";
-import { DecimalJSScalar } from \\"../../scalars\\";
+import { DecimalJSScalar, BytesScalar } from \\"../../scalars\\";
 import { FirstModelUncheckedCreateWithoutSecondModelsFieldInput } from \\"../inputs/FirstModelUncheckedCreateWithoutSecondModelsFieldInput\\";
 import { FirstModelUncheckedUpdateWithoutSecondModelsFieldInput } from \\"../inputs/FirstModelUncheckedUpdateWithoutSecondModelsFieldInput\\";
 import { FirstModelWhereInput } from \\"../inputs/FirstModelWhereInput\\";
@@ -8780,7 +8772,7 @@ export { FirstModelMaxOrderByAggregateInput } from \\"./FirstModelMaxOrderByAggr
 export { FirstModelMinOrderByAggregateInput } from \\"./FirstModelMinOrderByAggregateInput\\";
 export { FirstModelOrderByWithAggregationInput } from \\"./FirstModelOrderByWithAggregationInput\\";
 export { FirstModelOrderByWithRelationInput } from \\"./FirstModelOrderByWithRelationInput\\";
-export { FirstModelRelationFilter } from \\"./FirstModelRelationFilter\\";
+export { FirstModelScalarRelationFilter } from \\"./FirstModelScalarRelationFilter\\";
 export { FirstModelScalarWhereWithAggregatesInput } from \\"./FirstModelScalarWhereWithAggregatesInput\\";
 export { FirstModelSumOrderByAggregateInput } from \\"./FirstModelSumOrderByAggregateInput\\";
 export { FirstModelUncheckedCreateInput } from \\"./FirstModelUncheckedCreateInput\\";

--- a/tests/regression/inputs.ts
+++ b/tests/regression/inputs.ts
@@ -368,9 +368,6 @@ describe("inputs", () => {
     const firstModelOrderByWithRelationInputTSFile = await readGeneratedFile(
       "/resolvers/inputs/FirstModelOrderByWithRelationInput.ts",
     );
-    const firstModelRelationFilterTSFile = await readGeneratedFile(
-      "/resolvers/inputs/FirstModelRelationFilter.ts",
-    );
     const secondModelWhereInputTSFile = await readGeneratedFile(
       "/resolvers/inputs/SecondModelWhereInput.ts",
     );
@@ -394,9 +391,6 @@ describe("inputs", () => {
     );
     expect(firstModelOrderByWithRelationInputTSFile).toMatchSnapshot(
       "FirstModelOrderByWithRelationInput",
-    );
-    expect(firstModelRelationFilterTSFile).toMatchSnapshot(
-      "FirstModelRelationFilter",
     );
     expect(secondModelWhereInputTSFile).toMatchSnapshot(
       "SecondModelWhereInput",
@@ -995,9 +989,6 @@ describe("inputs", () => {
         await readGeneratedFile(
           "/resolvers/inputs/RenamedFirstModelOrderByWithRelationInput.ts",
         );
-      const renamedFirstModelRelationFilterTSFile = await readGeneratedFile(
-        "/resolvers/inputs/RenamedFirstModelRelationFilter.ts",
-      );
       const renamedSecondModelWhereInputTSFile = await readGeneratedFile(
         "/resolvers/inputs/RenamedSecondModelWhereInput.ts",
       );
@@ -1025,9 +1016,6 @@ describe("inputs", () => {
       );
       expect(renamedFirstModelOrderByWithRelationInputTSFile).toMatchSnapshot(
         "RenamedFirstModelOrderByWithRelationInput",
-      );
-      expect(renamedFirstModelRelationFilterTSFile).toMatchSnapshot(
-        "RenamedFirstModelRelationFilter",
       );
       expect(renamedSecondModelWhereInputTSFile).toMatchSnapshot(
         "RenamedSecondModelWhereInput",


### PR DESCRIPTION
The `getInputKeywordPhrasePosition` helper function was failing to correctly parse input type names that include `ScalarRelationFilter`. This was because `"ScalarRelationFilter"` was missing from the list of keywords, leading to incorrect model name identification. This commit adds the missing keyword, ensuring the generator correctly parses these new DMMF type names.

This fix aligns the generator with an evolution in Prisma's underlying data model, which now generates the new `ScalarRelationFilter` type. As a direct consequence, files like `FirstModelRelationFilter.ts` are no longer created.

The test code that attempted to read this obsolete file and perform a snapshot assertion has been removed, as it would cause a "file not found" error. The remaining test snapshots have been updated to reflect the new, correct output.